### PR TITLE
add GetRelease method

### DIFF
--- a/flag/service/cnr/cnr.go
+++ b/flag/service/cnr/cnr.go
@@ -2,5 +2,6 @@ package cnr
 
 // CNR is a data structure to hold CNR specific command line configuration flags.
 type CNR struct {
-	Address string
+	Address      string
+	Organization string
 }

--- a/main.go
+++ b/main.go
@@ -138,6 +138,7 @@ func mainWithError() (err error) {
 
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
 	daemonCommand.PersistentFlags().String(f.Service.CNR.Address, "https://quay.io", "Address used to connect to CNR, defaults to quay's managed offering.")
+	daemonCommand.PersistentFlags().String(f.Service.CNR.Organization, "giantswarm", "CNR organization.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, true, "Whether to use the in-cluster config to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CAFile, "", "Certificate authority file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")

--- a/service/chartconfig/v1/appr/appr.go
+++ b/service/chartconfig/v1/appr/appr.go
@@ -44,7 +44,7 @@ func New(config Config) (*Client, error) {
 
 	// set client timeout to prevent leakages.
 	hc := &http.Client{
-		Timeout: time.Second * 5,
+		Timeout: time.Second * httpClientTimeout,
 	}
 
 	u, err := url.Parse(config.Address + "/" + config.Organization + "/")

--- a/service/chartconfig/v1/appr/appr.go
+++ b/service/chartconfig/v1/appr/appr.go
@@ -2,6 +2,14 @@
 package appr
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/chart-operator/service/chartconfig/v1/key"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 )
@@ -10,14 +18,16 @@ import (
 type Config struct {
 	Logger micrologger.Logger
 
-	Address string
+	Address      string
+	Organization string
 }
 
 // Client knows how to talk with a CNR server.
 type Client struct {
-	logger micrologger.Logger
+	httpClient *http.Client
+	logger     micrologger.Logger
 
-	address string
+	base *url.URL
 }
 
 // New creates a new configured appr client.
@@ -25,16 +35,80 @@ func New(config Config) (*Client, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "logger must not be empty")
 	}
-
 	if config.Address == "" {
 		return nil, microerror.Maskf(invalidConfigError, "address must not be empty")
+	}
+	if config.Organization == "" {
+		return nil, microerror.Maskf(invalidConfigError, "organization must not be empty")
+	}
+
+	// set client timeout to prevent leakages.
+	hc := &http.Client{
+		Timeout: time.Second * 5,
+	}
+
+	u, err := url.Parse(config.Address + "/" + config.Organization + "/")
+	if err != nil {
+		return nil, microerror.Mask(err)
 	}
 
 	newAppr := &Client{
 		logger: config.Logger,
 
-		address: config.Address,
+		base:       u,
+		httpClient: hc,
 	}
 
 	return newAppr, nil
+}
+
+// GetRelease queries CNR for the release name of the chart represented by the
+// given custom object
+func (c *Client) GetRelease(customObject v1alpha1.ChartConfig) (string, error) {
+	chartName := key.ChartName(customObject)
+
+	req, err := c.newRequest("GET", chartName)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	var pkg Package
+	_, err = c.do(req, &pkg)
+
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return pkg.Release, nil
+}
+
+func (c *Client) newRequest(method, path string) (*http.Request, error) {
+	u := &url.URL{Path: path}
+	dest := c.base.ResolveReference(u)
+
+	var buf io.ReadWriter
+
+	req, err := http.NewRequest(method, dest.String(), buf)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	return req, nil
+}
+
+func (c *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(v)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return resp, nil
 }

--- a/service/chartconfig/v1/appr/appr_test.go
+++ b/service/chartconfig/v1/appr/appr_test.go
@@ -1,0 +1,99 @@
+package appr_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/chart-operator/service/chartconfig/v1/appr"
+)
+
+func TestGetRelease(t *testing.T) {
+	customObject := v1alpha1.ChartConfig{
+		Spec: v1alpha1.ChartConfigSpec{
+			Chart: v1alpha1.ChartConfigSpecChart{
+				Name: "chartname",
+			},
+		},
+	}
+	tcs := []struct {
+		description     string
+		h               func(w http.ResponseWriter, r *http.Request)
+		expectedError   bool
+		expectedRelease string
+	}{
+		{
+			description: "basic case",
+			h: func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasPrefix(r.URL.Path, "/giantswarm/chartname") {
+					http.Error(w, "wrong path", http.StatusInternalServerError)
+					fmt.Println(r.URL.Path)
+					return
+				}
+
+				pkg := appr.Package{
+					Release: "3.2.1",
+				}
+				js, err := json.Marshal(pkg)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(js)
+			},
+			expectedRelease: "3.2.1",
+		},
+		{
+			description: "wrongly formated response",
+			h: func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("not json"))
+			},
+			expectedError: true,
+		},
+		{
+			description: "server error",
+			h: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "500!!", http.StatusInternalServerError)
+				return
+			},
+			expectedError: true,
+		},
+	}
+
+	c := appr.Config{
+		Logger:       microloggertest.New(),
+		Organization: "giantswarm",
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(tc.h))
+			defer ts.Close()
+
+			c.Address = ts.URL
+			a, err := appr.New(c)
+			if err != nil {
+				t.Errorf("could not create appr %v", err)
+			}
+
+			r, err := a.GetRelease(customObject)
+			if err != nil && !tc.expectedError {
+				t.Errorf("failed to get release %v", err)
+			}
+			if err == nil && tc.expectedError {
+				t.Errorf("expected error didn't happen")
+			}
+
+			if r != tc.expectedRelease {
+				t.Errorf("didn't get expected release name, want %q, got %q", tc.expectedRelease, r)
+			}
+		})
+	}
+}

--- a/service/chartconfig/v1/appr/appr_test.go
+++ b/service/chartconfig/v1/appr/appr_test.go
@@ -84,10 +84,10 @@ func TestGetRelease(t *testing.T) {
 			}
 
 			r, err := a.GetRelease(customObject)
-			if err != nil && !tc.expectedError {
+			switch {
+			case err != nil && !tc.expectedError:
 				t.Errorf("failed to get release %v", err)
-			}
-			if err == nil && tc.expectedError {
+			case err == nil && tc.expectedError:
 				t.Errorf("expected error didn't happen")
 			}
 

--- a/service/chartconfig/v1/appr/spec.go
+++ b/service/chartconfig/v1/appr/spec.go
@@ -1,0 +1,5 @@
+package appr
+
+type Package struct {
+	Release string `json:"release"`
+}

--- a/service/chartconfig/v1/appr/spec.go
+++ b/service/chartconfig/v1/appr/spec.go
@@ -1,5 +1,10 @@
 package appr
 
+const (
+	httpClientTimeout = 5
+)
+
+// Package represents a CNR application.
 type Package struct {
 	Release string `json:"release"`
 }

--- a/service/chartconfig/v1/resource/chart/desired_test.go
+++ b/service/chartconfig/v1/resource/chart/desired_test.go
@@ -37,8 +37,9 @@ func Test_DesiredState(t *testing.T) {
 	}
 
 	c := appr.Config{
-		Address: "http://127.0.0.1:5555",
-		Logger:  microloggertest.New(),
+		Address:      "http://127.0.0.1:5555",
+		Logger:       microloggertest.New(),
+		Organization: "giantswarm",
 	}
 	apprClient, err := appr.New(c)
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -87,8 +87,10 @@ func New(config Config) (*Service, error) {
 	var apprClient *appr.Client
 	{
 		c := appr.Config{
-			Logger:  config.Logger,
-			Address: config.Viper.GetString(config.Flag.Service.CNR.Address),
+			Logger: config.Logger,
+
+			Address:      config.Viper.GetString(config.Flag.Service.CNR.Address),
+			Organization: config.Viper.GetString(config.Flag.Service.CNR.Organization),
 		}
 		apprClient, err = appr.New(c)
 		if err != nil {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -28,6 +28,7 @@ func Test_Service_New(t *testing.T) {
 
 				c.Viper.Set(c.Flag.Service.Kubernetes.Address, "https://127.0.0.1:8443")
 				c.Viper.Set(c.Flag.Service.CNR.Address, "https://127.0.0.1:5555")
+				c.Viper.Set(c.Flag.Service.CNR.Organization, "giantswarm")
 				c.Viper.Set(c.Flag.Service.Kubernetes.InCluster, false)
 
 				return c


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902

Adds initial client code and `GetRelease` method required by the desired state calculations in the chart resource.

Looking at CNR API it's very easy to write a REST client, I've taken this approach here instead of using helm plus the registry plugin (or the appr python code directly). 

I'll propose next the wiring with the chart resource, we need an interface in order to setup proper mocking and not having to spin up a server for chart unit tests. We'll have soon in place e2e tests with an actual CNR server from https://github.com/giantswarm/docker-cnr-server.