### PR TITLE
Add ReleaseName to ChartState

### DIFF
--- a/service/chartconfig/v1/key/key.go
+++ b/service/chartconfig/v1/key/key.go
@@ -13,6 +13,10 @@ func ChannelName(customObject v1alpha1.ChartConfig) string {
 	return customObject.Spec.Chart.Channel
 }
 
+func ReleaseName(customObject v1alpha1.ChartConfig) string {
+	return customObject.Spec.Chart.Release
+}
+
 // ToCustomObject converts value to v1alpha1.ChartConfig and returns it or error
 // if type does not match.
 func ToCustomObject(v interface{}) (v1alpha1.ChartConfig, error) {

--- a/service/chartconfig/v1/key/key_test.go
+++ b/service/chartconfig/v1/key/key_test.go
@@ -1,6 +1,7 @@
 package key
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
@@ -37,5 +38,57 @@ func Test_ChannelName(t *testing.T) {
 
 	if ChannelName(obj) != expectedChannel {
 		t.Fatalf("chart name %s, want %s", ChannelName(obj), expectedChannel)
+	}
+}
+
+func Test_ToCustomObject(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          interface{}
+		expectedObject v1alpha1.ChartConfig
+		errorMatcher   func(error) bool
+	}{
+		{
+			name: "case 0: basic match",
+			input: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name:    "chart-operator-chart",
+						Channel: "0.1-beta",
+					},
+				},
+			},
+			expectedObject: v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name:    "chart-operator-chart",
+						Channel: "0.1-beta",
+					},
+				},
+			},
+		},
+		{
+			name:         "case 1: wrong type",
+			input:        &v1alpha1.CertConfig{},
+			errorMatcher: IsWrongTypeError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ToCustomObject(tc.input)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedObject) {
+				t.Fatalf("Custom Object == %q, want %q", result, tc.expectedObject)
+			}
+		})
 	}
 }

--- a/service/chartconfig/v1/key/key_test.go
+++ b/service/chartconfig/v1/key/key_test.go
@@ -15,6 +15,7 @@ func Test_ChartName(t *testing.T) {
 			Chart: v1alpha1.ChartConfigSpecChart{
 				Name:    "chart-operator-chart",
 				Channel: "0.1-beta",
+				Release: "chart-operator",
 			},
 		},
 	}
@@ -32,12 +33,31 @@ func Test_ChannelName(t *testing.T) {
 			Chart: v1alpha1.ChartConfigSpecChart{
 				Name:    "chart-operator-chart",
 				Channel: "0.1-beta",
+				Release: "chart-operator",
 			},
 		},
 	}
 
 	if ChannelName(obj) != expectedChannel {
-		t.Fatalf("chart name %s, want %s", ChannelName(obj), expectedChannel)
+		t.Fatalf("channel name %s, want %s", ChannelName(obj), expectedChannel)
+	}
+}
+
+func Test_ReleaseName(t *testing.T) {
+	expectedRelease := "chart-operator"
+
+	obj := v1alpha1.ChartConfig{
+		Spec: v1alpha1.ChartConfigSpec{
+			Chart: v1alpha1.ChartConfigSpecChart{
+				Name:    "chart-operator-chart",
+				Channel: "0.1-beta",
+				Release: "chart-operator",
+			},
+		},
+	}
+
+	if ReleaseName(obj) != expectedRelease {
+		t.Fatalf("release name %s, want %s", ReleaseName(obj), expectedRelease)
 	}
 }
 
@@ -55,6 +75,7 @@ func Test_ToCustomObject(t *testing.T) {
 					Chart: v1alpha1.ChartConfigSpecChart{
 						Name:    "chart-operator-chart",
 						Channel: "0.1-beta",
+						Release: "chart-operator",
 					},
 				},
 			},
@@ -63,6 +84,7 @@ func Test_ToCustomObject(t *testing.T) {
 					Chart: v1alpha1.ChartConfigSpecChart{
 						Name:    "chart-operator-chart",
 						Channel: "0.1-beta",
+						Release: "chart-operator",
 					},
 				},
 			},

--- a/service/chartconfig/v1/resource/chart/desired.go
+++ b/service/chartconfig/v1/resource/chart/desired.go
@@ -22,6 +22,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	chartState := &ChartState{
 		ChartName:      key.ChartName(customObject),
 		ChannelName:    key.ChannelName(customObject),
+		ReleaseName:    key.ReleaseName(customObject),
 		ReleaseVersion: releaseVersion,
 	}
 

--- a/service/chartconfig/v1/resource/chart/desired_test.go
+++ b/service/chartconfig/v1/resource/chart/desired_test.go
@@ -23,12 +23,14 @@ func Test_DesiredState(t *testing.T) {
 					Chart: v1alpha1.ChartConfigSpecChart{
 						Name:    "quay.io/giantswarm/chart-operator-chart",
 						Channel: "0.1-beta",
+						Release: "chart-operator",
 					},
 				},
 			},
 			expectedState: ChartState{
 				ChartName:      "quay.io/giantswarm/chart-operator-chart",
 				ChannelName:    "0.1-beta",
+				ReleaseName:    "chart-operator",
 				ReleaseVersion: "0.1.2",
 			},
 		},

--- a/service/chartconfig/v1/resource/chart/spec.go
+++ b/service/chartconfig/v1/resource/chart/spec.go
@@ -8,6 +8,9 @@ type ChartState struct {
 	// ChannelName is the CNR channel to reconcile against.
 	// e.g. 0.1-beta
 	ChannelName string
+	// ReleaseName is the name of the Helm release when the chart is deployed.
+	// e.g. chart-operator
+	ReleaseName string
 	// ReleaseVersion is the version of the Helm Chart to be deployed.
 	// e.g. 0.1.2
 	ReleaseVersion string


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

This is prep for landing #18 which has got a bit big. Adds `ReleaseName` to the `ChartState` following the earlier change to `apiextensions`.

Also some boyscouting to add test coverage for `key.ToCustomObject`.