### PR TITLE
Get release content

### DIFF
--- a/service/chartconfig/v1/helm/spec.go
+++ b/service/chartconfig/v1/helm/spec.go
@@ -7,10 +7,12 @@ type Interface interface {
 	GetReleaseContent(v1alpha1.ChartConfig) (*Release, error)
 }
 
-// Release returns information about a Helm release.
+// Release returns information about a Helm Release.
 type Release struct {
-	// Name is the name of the Helm release.
+	// Name is the name of the Helm Release.
 	Name string
-	// Status is the Helm status code of the release.
+	// Status is the Helm status code of the Release.
 	Status string
+	// Values are the values provided when installing the Helm Release.
+	Values map[string]interface{}
 }

--- a/service/chartconfig/v1/resource/chart/resource_test.go
+++ b/service/chartconfig/v1/resource/chart/resource_test.go
@@ -16,12 +16,14 @@ func Test_toChartState(t *testing.T) {
 			input: &ChartState{
 				ChartName:      "test-chart",
 				ChannelName:    "test-channel",
-				ReleaseVersion: "test-release",
+				ReleaseName:    "test-release",
+				ReleaseVersion: "0.1.0",
 			},
 			expectedState: ChartState{
 				ChartName:      "test-chart",
 				ChannelName:    "test-channel",
-				ReleaseVersion: "test-release",
+				ReleaseName:    "test-release",
+				ReleaseVersion: "0.1.0",
 			},
 		},
 		{
@@ -29,7 +31,8 @@ func Test_toChartState(t *testing.T) {
 			input: ChartState{
 				ChartName:      "test-chart",
 				ChannelName:    "test-channel",
-				ReleaseVersion: "test-release",
+				ReleaseName:    "test-release",
+				ReleaseVersion: "0.1.0",
 			},
 			errorMatcher: IsWrongType,
 		},


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Updates `GetReleaseContent` to get the status and any values that have been set when the Chart was installed.