### PR TITLE
Release history

### DIFF
--- a/service/chartconfig/v1/helm/error.go
+++ b/service/chartconfig/v1/helm/error.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	releaseNotFoundErrorPrefix = "No such release:"
+	releaseNotFoundErrorSuffix = "not found"
 )
 
 var invalidConfigError = microerror.New("invalid config")
@@ -26,9 +27,16 @@ func IsReleaseNotFound(err error) bool {
 	if strings.HasPrefix(c.Error(), releaseNotFoundErrorPrefix) {
 		return true
 	}
-	if c == releaseNotFoundError {
+	if strings.HasSuffix(c.Error(), releaseNotFoundErrorSuffix) {
 		return true
 	}
 
 	return false
+}
+
+var tooManyResultsError = microerror.New("too many results")
+
+// IsTooManyResults asserts tooManyResultsError.
+func IsTooManyResults(err error) bool {
+	return microerror.Cause(err) == tooManyResultsError
 }

--- a/service/chartconfig/v1/helm/helm.go
+++ b/service/chartconfig/v1/helm/helm.go
@@ -49,7 +49,7 @@ func New(config Config) (*Client, error) {
 
 // GetReleaseContent gets the current status of the Helm Release including any
 // values provided when the chart was installed.
-func (c *Client) GetReleaseContent(customObject v1alpha1.ChartConfig) (*Release, error) {
+func (c *Client) GetReleaseContent(customObject v1alpha1.ChartConfig) (*ReleaseContent, error) {
 	releaseName := key.ReleaseName(customObject)
 
 	resp, err := c.helmClient.ReleaseContent(releaseName)
@@ -67,7 +67,7 @@ func (c *Client) GetReleaseContent(customObject v1alpha1.ChartConfig) (*Release,
 		return nil, microerror.Mask(err)
 	}
 
-	release := &Release{
+	release := &ReleaseContent{
 		Name:   resp.Release.Name,
 		Status: resp.Release.Info.Status.Code.String(),
 		Values: values.AsMap(),

--- a/service/chartconfig/v1/helm/helm.go
+++ b/service/chartconfig/v1/helm/helm.go
@@ -67,11 +67,11 @@ func (c *Client) GetReleaseContent(customObject v1alpha1.ChartConfig) (*ReleaseC
 		return nil, microerror.Mask(err)
 	}
 
-	release := &ReleaseContent{
+	content := &ReleaseContent{
 		Name:   resp.Release.Name,
 		Status: resp.Release.Info.Status.Code.String(),
 		Values: values.AsMap(),
 	}
 
-	return release, nil
+	return content, nil
 }

--- a/service/chartconfig/v1/helm/helm_test.go
+++ b/service/chartconfig/v1/helm/helm_test.go
@@ -15,7 +15,7 @@ func Test_GetReleaseContent(t *testing.T) {
 		description     string
 		obj             v1alpha1.ChartConfig
 		releases        []*helmrelease.Release
-		expectedRelease *ReleaseContent
+		expectedContent *ReleaseContent
 		errorMatcher    func(error) bool
 	}{
 		{
@@ -35,7 +35,7 @@ func Test_GetReleaseContent(t *testing.T) {
 					Namespace: "default",
 				}),
 			},
-			expectedRelease: &ReleaseContent{
+			expectedContent: &ReleaseContent{
 				Name:   "chart-operator",
 				Status: "DEPLOYED",
 				Values: map[string]interface{}{
@@ -63,7 +63,7 @@ func Test_GetReleaseContent(t *testing.T) {
 					StatusCode: helmrelease.Status_FAILED,
 				}),
 			},
-			expectedRelease: &ReleaseContent{
+			expectedContent: &ReleaseContent{
 				Name:   "chart-operator",
 				Status: "FAILED",
 				Values: map[string]interface{}{
@@ -88,7 +88,7 @@ func Test_GetReleaseContent(t *testing.T) {
 					Name: "chart-operator",
 				}),
 			},
-			expectedRelease: nil,
+			expectedContent: nil,
 			errorMatcher:    IsReleaseNotFound,
 		},
 	}
@@ -114,8 +114,8 @@ func Test_GetReleaseContent(t *testing.T) {
 				t.Fatalf("error == %#v, want matching", err)
 			}
 
-			if !reflect.DeepEqual(result, tc.expectedRelease) {
-				t.Fatalf("Release == %q, want %q", result, tc.expectedRelease)
+			if !reflect.DeepEqual(result, tc.expectedContent) {
+				t.Fatalf("Release == %q, want %q", result, tc.expectedContent)
 			}
 		})
 	}

--- a/service/chartconfig/v1/helm/helm_test.go
+++ b/service/chartconfig/v1/helm/helm_test.go
@@ -15,7 +15,7 @@ func Test_GetReleaseContent(t *testing.T) {
 		description     string
 		obj             v1alpha1.ChartConfig
 		releases        []*helmrelease.Release
-		expectedRelease *Release
+		expectedRelease *ReleaseContent
 		errorMatcher    func(error) bool
 	}{
 		{
@@ -35,7 +35,7 @@ func Test_GetReleaseContent(t *testing.T) {
 					Namespace: "default",
 				}),
 			},
-			expectedRelease: &Release{
+			expectedRelease: &ReleaseContent{
 				Name:   "chart-operator",
 				Status: "DEPLOYED",
 				Values: map[string]interface{}{
@@ -63,7 +63,7 @@ func Test_GetReleaseContent(t *testing.T) {
 					StatusCode: helmrelease.Status_FAILED,
 				}),
 			},
-			expectedRelease: &Release{
+			expectedRelease: &ReleaseContent{
 				Name:   "chart-operator",
 				Status: "FAILED",
 				Values: map[string]interface{}{

--- a/service/chartconfig/v1/helm/spec.go
+++ b/service/chartconfig/v1/helm/spec.go
@@ -5,6 +5,7 @@ import "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 // Interface describes the methods provided by the helm client.
 type Interface interface {
 	GetReleaseContent(v1alpha1.ChartConfig) (*ReleaseContent, error)
+	GetReleaseHistory(v1alpha1.ChartConfig) (*ReleaseHistory, error)
 }
 
 // ReleaseContent returns status information about a Helm Release.
@@ -15,4 +16,12 @@ type ReleaseContent struct {
 	Status string
 	// Values are the values provided when installing the Helm Release.
 	Values map[string]interface{}
+}
+
+// ReleaseHistory returns version information about a Helm Release.
+type ReleaseHistory struct {
+	// Name is the name of the Helm Release.
+	Name string
+	// ReleaseVersion is the version of the Helm Chart to be deployed.
+	ReleaseVersion string
 }

--- a/service/chartconfig/v1/helm/spec.go
+++ b/service/chartconfig/v1/helm/spec.go
@@ -4,11 +4,11 @@ import "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 
 // Interface describes the methods provided by the helm client.
 type Interface interface {
-	GetReleaseContent(v1alpha1.ChartConfig) (*Release, error)
+	GetReleaseContent(v1alpha1.ChartConfig) (*ReleaseContent, error)
 }
 
-// Release returns information about a Helm Release.
-type Release struct {
+// ReleaseContent returns status information about a Helm Release.
+type ReleaseContent struct {
 	// Name is the name of the Helm Release.
 	Name string
 	// Status is the Helm status code of the Release.

--- a/service/chartconfig/v1/resource/chart/mocks.go
+++ b/service/chartconfig/v1/resource/chart/mocks.go
@@ -32,3 +32,11 @@ func (a *helmMock) GetReleaseContent(customObject v1alpha1.ChartConfig) (*helm.R
 
 	return &helm.ReleaseContent{}, nil
 }
+
+func (a *helmMock) GetReleaseHistory(customObject v1alpha1.ChartConfig) (*helm.ReleaseHistory, error) {
+	if a.expectedError {
+		return nil, fmt.Errorf("error getting release history")
+	}
+
+	return &helm.ReleaseHistory{}, nil
+}

--- a/service/chartconfig/v1/resource/chart/mocks.go
+++ b/service/chartconfig/v1/resource/chart/mocks.go
@@ -25,10 +25,10 @@ type helmMock struct {
 	expectedError bool
 }
 
-func (a *helmMock) GetReleaseContent(customObject v1alpha1.ChartConfig) (*helm.Release, error) {
+func (a *helmMock) GetReleaseContent(customObject v1alpha1.ChartConfig) (*helm.ReleaseContent, error) {
 	if a.expectedError {
 		return nil, fmt.Errorf("error getting release content")
 	}
 
-	return &helm.Release{}, nil
+	return &helm.ReleaseContent{}, nil
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Adds GetReleaseHistory to Helm client for getting the current installed version of the chart.