### PR TITLE
Decouple helm package from chartconfig CRD

### DIFF
--- a/service/chartconfig/v1/helm/helm.go
+++ b/service/chartconfig/v1/helm/helm.go
@@ -45,7 +45,8 @@ func New(config Config) (*Client, error) {
 }
 
 // GetReleaseContent gets the current status of the Helm Release including any
-// values provided when the chart was installed.
+// values provided when the chart was installed. The releaseName is the name
+// of the Helm Release that is set when the Helm Chart is installed.
 func (c *Client) GetReleaseContent(releaseName string) (*ReleaseContent, error) {
 	resp, err := c.helmClient.ReleaseContent(releaseName)
 	if IsReleaseNotFound(err) {
@@ -71,6 +72,8 @@ func (c *Client) GetReleaseContent(releaseName string) (*ReleaseContent, error) 
 }
 
 // GetReleaseHistory gets the current installed version of the Helm Release.
+// The releaseName is the name of the Helm Release that is set when the Helm
+// Chart is installed
 func (c *Client) GetReleaseHistory(releaseName string) (*ReleaseHistory, error) {
 	var version string
 

--- a/service/chartconfig/v1/helm/helm.go
+++ b/service/chartconfig/v1/helm/helm.go
@@ -73,7 +73,7 @@ func (c *Client) GetReleaseContent(releaseName string) (*ReleaseContent, error) 
 
 // GetReleaseHistory gets the current installed version of the Helm Release.
 // The releaseName is the name of the Helm Release that is set when the Helm
-// Chart is installed
+// Chart is installed.
 func (c *Client) GetReleaseHistory(releaseName string) (*ReleaseHistory, error) {
 	var version string
 

--- a/service/chartconfig/v1/helm/helm.go
+++ b/service/chartconfig/v1/helm/helm.go
@@ -1,13 +1,10 @@
 package helm
 
 import (
-	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/helm/pkg/chartutil"
 	helmclient "k8s.io/helm/pkg/helm"
-
-	"github.com/giantswarm/chart-operator/service/chartconfig/v1/key"
 )
 
 const (
@@ -49,9 +46,7 @@ func New(config Config) (*Client, error) {
 
 // GetReleaseContent gets the current status of the Helm Release including any
 // values provided when the chart was installed.
-func (c *Client) GetReleaseContent(customObject v1alpha1.ChartConfig) (*ReleaseContent, error) {
-	releaseName := key.ReleaseName(customObject)
-
+func (c *Client) GetReleaseContent(releaseName string) (*ReleaseContent, error) {
 	resp, err := c.helmClient.ReleaseContent(releaseName)
 	if IsReleaseNotFound(err) {
 		return nil, microerror.Maskf(releaseNotFoundError, releaseName)
@@ -76,10 +71,8 @@ func (c *Client) GetReleaseContent(customObject v1alpha1.ChartConfig) (*ReleaseC
 }
 
 // GetReleaseHistory gets the current installed version of the Helm Release.
-func (c *Client) GetReleaseHistory(customObject v1alpha1.ChartConfig) (*ReleaseHistory, error) {
+func (c *Client) GetReleaseHistory(releaseName string) (*ReleaseHistory, error) {
 	var version string
-
-	releaseName := key.ReleaseName(customObject)
 
 	resp, err := c.helmClient.ReleaseHistory(releaseName, helmclient.WithMaxHistory(1))
 	if IsReleaseNotFound(err) {

--- a/service/chartconfig/v1/helm/helm_test.go
+++ b/service/chartconfig/v1/helm/helm_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 	helmclient "k8s.io/helm/pkg/helm"
 	helmchart "k8s.io/helm/pkg/proto/hapi/chart"
@@ -14,22 +13,14 @@ import (
 func Test_GetReleaseContent(t *testing.T) {
 	testCases := []struct {
 		description     string
-		obj             v1alpha1.ChartConfig
+		releaseName     string
 		releases        []*helmrelease.Release
 		expectedContent *ReleaseContent
 		errorMatcher    func(error) bool
 	}{
 		{
 			description: "case 0: basic match with deployed status",
-			obj: v1alpha1.ChartConfig{
-				Spec: v1alpha1.ChartConfigSpec{
-					Chart: v1alpha1.ChartConfigSpecChart{
-						Name:    "quay.io/giantswarm/chart-operator-chart",
-						Channel: "0.1-beta",
-						Release: "chart-operator",
-					},
-				},
-			},
+			releaseName: "chart-operator",
 			releases: []*helmrelease.Release{
 				helmclient.ReleaseMock(&helmclient.MockReleaseOptions{
 					Name:      "chart-operator",
@@ -48,15 +39,7 @@ func Test_GetReleaseContent(t *testing.T) {
 		},
 		{
 			description: "case 1: basic match with failed status",
-			obj: v1alpha1.ChartConfig{
-				Spec: v1alpha1.ChartConfigSpec{
-					Chart: v1alpha1.ChartConfigSpecChart{
-						Name:    "quay.io/giantswarm/chart-operator-chart",
-						Channel: "0.1-beta",
-						Release: "chart-operator",
-					},
-				},
-			},
+			releaseName: "chart-operator",
 			releases: []*helmrelease.Release{
 				helmclient.ReleaseMock(&helmclient.MockReleaseOptions{
 					Name:       "chart-operator",
@@ -75,15 +58,7 @@ func Test_GetReleaseContent(t *testing.T) {
 		},
 		{
 			description: "case 2: chart not found",
-			obj: v1alpha1.ChartConfig{
-				Spec: v1alpha1.ChartConfigSpec{
-					Chart: v1alpha1.ChartConfigSpecChart{
-						Name:    "missing-chart",
-						Channel: "stable",
-						Release: "missing",
-					},
-				},
-			},
+			releaseName: "missing",
 			releases: []*helmrelease.Release{
 				helmclient.ReleaseMock(&helmclient.MockReleaseOptions{
 					Name: "chart-operator",
@@ -102,7 +77,7 @@ func Test_GetReleaseContent(t *testing.T) {
 				},
 				logger: microloggertest.New(),
 			}
-			result, err := helm.GetReleaseContent(tc.obj)
+			result, err := helm.GetReleaseContent(tc.releaseName)
 
 			switch {
 			case err == nil && tc.errorMatcher == nil:
@@ -125,22 +100,14 @@ func Test_GetReleaseContent(t *testing.T) {
 func Test_GetReleaseHistory(t *testing.T) {
 	testCases := []struct {
 		description     string
-		obj             v1alpha1.ChartConfig
+		releaseName     string
 		releases        []*helmrelease.Release
 		expectedHistory *ReleaseHistory
 		errorMatcher    func(error) bool
 	}{
 		{
 			description: "case 0: basic match with version",
-			obj: v1alpha1.ChartConfig{
-				Spec: v1alpha1.ChartConfigSpec{
-					Chart: v1alpha1.ChartConfigSpecChart{
-						Name:    "quay.io/giantswarm/chart-operator-chart",
-						Channel: "0.1-beta",
-						Release: "chart-operator",
-					},
-				},
-			},
+			releaseName: "chart-operator",
 			releases: []*helmrelease.Release{
 				helmclient.ReleaseMock(&helmclient.MockReleaseOptions{
 					Name:      "chart-operator",
@@ -160,15 +127,7 @@ func Test_GetReleaseHistory(t *testing.T) {
 		},
 		{
 			description: "case 1: different version",
-			obj: v1alpha1.ChartConfig{
-				Spec: v1alpha1.ChartConfigSpec{
-					Chart: v1alpha1.ChartConfigSpecChart{
-						Name:    "quay.io/giantswarm/chart-operator-chart",
-						Channel: "0.1-beta",
-						Release: "chart-operator",
-					},
-				},
-			},
+			releaseName: "chart-operator",
 			releases: []*helmrelease.Release{
 				helmclient.ReleaseMock(&helmclient.MockReleaseOptions{
 					Name:      "chart-operator",
@@ -188,15 +147,7 @@ func Test_GetReleaseHistory(t *testing.T) {
 		},
 		{
 			description: "case 2: too many results",
-			obj: v1alpha1.ChartConfig{
-				Spec: v1alpha1.ChartConfigSpec{
-					Chart: v1alpha1.ChartConfigSpecChart{
-						Name:    "quay.io/giantswarm/chart-operator-chart",
-						Channel: "0.1-beta",
-						Release: "missing",
-					},
-				},
-			},
+			releaseName: "missing",
 			releases: []*helmrelease.Release{
 				helmclient.ReleaseMock(&helmclient.MockReleaseOptions{
 					Name:      "chart-operator",
@@ -230,7 +181,7 @@ func Test_GetReleaseHistory(t *testing.T) {
 				},
 				logger: microloggertest.New(),
 			}
-			result, err := helm.GetReleaseHistory(tc.obj)
+			result, err := helm.GetReleaseHistory(tc.releaseName)
 
 			switch {
 			case err == nil && tc.errorMatcher == nil:

--- a/service/chartconfig/v1/helm/spec.go
+++ b/service/chartconfig/v1/helm/spec.go
@@ -1,11 +1,9 @@
 package helm
 
-import "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
-
 // Interface describes the methods provided by the helm client.
 type Interface interface {
-	GetReleaseContent(v1alpha1.ChartConfig) (*ReleaseContent, error)
-	GetReleaseHistory(v1alpha1.ChartConfig) (*ReleaseHistory, error)
+	GetReleaseContent(releaseName string) (*ReleaseContent, error)
+	GetReleaseHistory(releaseName string) (*ReleaseHistory, error)
 	InstallFromTarball(path string) error
 }
 

--- a/service/chartconfig/v1/helm/spec.go
+++ b/service/chartconfig/v1/helm/spec.go
@@ -8,7 +8,7 @@ type Interface interface {
 	GetReleaseContent(releaseName string) (*ReleaseContent, error)
 	// GetReleaseHistory gets the current installed version of the Helm Release.
 	// The releaseName is the name of the Helm Release that is set when the Helm
-	// Chart is installed
+	// Chart is installed.
 	GetReleaseHistory(releaseName string) (*ReleaseHistory, error)
 	// InstallFromTarball installs a Helm Chart packaged in the given tarball.
 	InstallFromTarball(path string) error

--- a/service/chartconfig/v1/helm/spec.go
+++ b/service/chartconfig/v1/helm/spec.go
@@ -2,8 +2,15 @@ package helm
 
 // Interface describes the methods provided by the helm client.
 type Interface interface {
+	// GetReleaseContent gets the current status of the Helm Release. The
+	// releaseName is the name of the Helm Release that is set when the Chart
+	// is installed.
 	GetReleaseContent(releaseName string) (*ReleaseContent, error)
+	// GetReleaseHistory gets the current installed version of the Helm Release.
+	// The releaseName is the name of the Helm Release that is set when the Helm
+	// Chart is installed
 	GetReleaseHistory(releaseName string) (*ReleaseHistory, error)
+	// InstallFromTarball installs a Helm Chart packaged in the given tarball.
 	InstallFromTarball(path string) error
 }
 

--- a/service/chartconfig/v1/resource/chart/current.go
+++ b/service/chartconfig/v1/resource/chart/current.go
@@ -15,7 +15,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	releaseContent, err := r.helmClient.GetReleaseContent(customObject)
+	releaseName := key.ReleaseName(customObject)
+	releaseContent, err := r.helmClient.GetReleaseContent(releaseName)
 	if helm.IsReleaseNotFound(err) {
 		// Return early as release is not installed.
 		return nil, nil
@@ -23,7 +24,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	releaseHistory, err := r.helmClient.GetReleaseHistory(customObject)
+	releaseHistory, err := r.helmClient.GetReleaseHistory(releaseName)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -31,7 +32,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	chartState := &ChartState{
 		ChartName:      key.ChartName(customObject),
 		ChannelName:    key.ChannelName(customObject),
-		ReleaseName:    key.ReleaseName(customObject),
+		ReleaseName:    releaseName,
 		ChartValues:    releaseContent.Values,
 		ReleaseStatus:  releaseContent.Status,
 		ReleaseVersion: releaseHistory.Version,

--- a/service/chartconfig/v1/resource/chart/mock_test.go
+++ b/service/chartconfig/v1/resource/chart/mock_test.go
@@ -3,8 +3,6 @@ package chart
 import (
 	"fmt"
 
-	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
-
 	"github.com/giantswarm/chart-operator/service/chartconfig/v1/helm"
 )
 
@@ -31,7 +29,7 @@ type helmMock struct {
 	defaultError          error
 }
 
-func (h *helmMock) GetReleaseContent(customObject v1alpha1.ChartConfig) (*helm.ReleaseContent, error) {
+func (h *helmMock) GetReleaseContent(releaseName string) (*helm.ReleaseContent, error) {
 	if h.defaultError != nil {
 		return nil, h.defaultError
 	}
@@ -39,7 +37,7 @@ func (h *helmMock) GetReleaseContent(customObject v1alpha1.ChartConfig) (*helm.R
 	return h.defaultReleaseContent, nil
 }
 
-func (h *helmMock) GetReleaseHistory(customObject v1alpha1.ChartConfig) (*helm.ReleaseHistory, error) {
+func (h *helmMock) GetReleaseHistory(releaseName string) (*helm.ReleaseHistory, error) {
 	if h.defaultError != nil {
 		return nil, h.defaultError
 	}


### PR DESCRIPTION
Some cleanup to decouple the helm client package from the chartconfig CRD. Interface is still clean without it and makes the client easier to reuse.