### PR TITLE
Fix kubernetes incluster setting in configmap

### DIFF
--- a/helm/chart-operator-chart/templates/configmap.yaml
+++ b/helm/chart-operator-chart/templates/configmap.yaml
@@ -8,8 +8,8 @@ data:
     server:
       listen:
         address: 'http://0.0.0.0:{{ .Values.port }}'
-      kubernetes:
-        incluster: true
     service:
       cnr:
         address: 'https://quay.io'
+      kubernetes:
+        incluster: true


### PR DESCRIPTION
Just noticed this when I installed the chart in minikube earlier. `incluster` should be in the service block.