### PR TITLE
Add DeleteRelease to helm client

### DIFF
--- a/service/chartconfig/v1/helm/helm.go
+++ b/service/chartconfig/v1/helm/helm.go
@@ -44,6 +44,16 @@ func New(config Config) (*Client, error) {
 	return newHelm, nil
 }
 
+// DeleteRelease uninstalls a chart given its release name
+func (c *Client) DeleteRelease(releaseName string, options ...helmclient.DeleteOption) error {
+	_, err := c.helmClient.DeleteRelease(releaseName, options...)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
 // GetReleaseContent gets the current status of the Helm Release including any
 // values provided when the chart was installed. The releaseName is the name
 // of the Helm Release that is set when the Helm Chart is installed.

--- a/service/chartconfig/v1/helm/helm.go
+++ b/service/chartconfig/v1/helm/helm.go
@@ -44,7 +44,7 @@ func New(config Config) (*Client, error) {
 	return newHelm, nil
 }
 
-// DeleteRelease uninstalls a chart given its release name
+// DeleteRelease uninstalls a chart given its release name.
 func (c *Client) DeleteRelease(releaseName string, options ...helmclient.DeleteOption) error {
 	_, err := c.helmClient.DeleteRelease(releaseName, options...)
 	if err != nil {

--- a/service/chartconfig/v1/helm/spec.go
+++ b/service/chartconfig/v1/helm/spec.go
@@ -4,7 +4,7 @@ import "k8s.io/helm/pkg/helm"
 
 // Interface describes the methods provided by the helm client.
 type Interface interface {
-	// DeleteRelease uninstalls a chart given its release name
+	// DeleteRelease uninstalls a chart given its release name.
 	DeleteRelease(releaseName string, options ...helm.DeleteOption) error
 	// GetReleaseContent gets the current status of the Helm Release. The
 	// releaseName is the name of the Helm Release that is set when the Chart

--- a/service/chartconfig/v1/helm/spec.go
+++ b/service/chartconfig/v1/helm/spec.go
@@ -4,6 +4,8 @@ import "k8s.io/helm/pkg/helm"
 
 // Interface describes the methods provided by the helm client.
 type Interface interface {
+	// DeleteRelease uninstalls a chart given its release name
+	DeleteRelease(releaseName string) error
 	// GetReleaseContent gets the current status of the Helm Release. The
 	// releaseName is the name of the Helm Release that is set when the Chart
 	// is installed.

--- a/service/chartconfig/v1/helm/spec.go
+++ b/service/chartconfig/v1/helm/spec.go
@@ -5,7 +5,7 @@ import "k8s.io/helm/pkg/helm"
 // Interface describes the methods provided by the helm client.
 type Interface interface {
 	// DeleteRelease uninstalls a chart given its release name
-	DeleteRelease(releaseName string) error
+	DeleteRelease(releaseName string, options ...helm.DeleteOption) error
 	// GetReleaseContent gets the current status of the Helm Release. The
 	// releaseName is the name of the Helm Release that is set when the Chart
 	// is installed.

--- a/service/chartconfig/v1/resource/chart/mock_test.go
+++ b/service/chartconfig/v1/resource/chart/mock_test.go
@@ -31,6 +31,14 @@ type helmMock struct {
 	defaultError          error
 }
 
+func (h *helmMock) DeleteRelease(releaseName string, options ...helmclient.DeleteOption) error {
+	if h.defaultError != nil {
+		return h.defaultError
+	}
+
+	return nil
+}
+
 func (h *helmMock) GetReleaseContent(releaseName string) (*helm.ReleaseContent, error) {
 	if h.defaultError != nil {
 		return nil, h.defaultError


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902.

Add method for uninstalling a charts to the helm client.

Next steps would be to implement the corresponding chart resource methods.
```
func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) 
func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState 
```