### PR TITLE
Add chart resource delete methods

### DIFF
--- a/service/chartconfig/v1/resource/chart/delete.go
+++ b/service/chartconfig/v1/resource/chart/delete.go
@@ -2,11 +2,36 @@ package chart
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/giantswarm/chart-operator/service/chartconfig/v1/key"
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	chartState, err := toChartState(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if chartState.ReleaseName != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %s", chartState.ReleaseName))
+		release := key.ReleaseName(customObject)
+
+		err := r.helmClient.DeleteRelease(release)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %s", chartState.ReleaseName))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting release %s", chartState.ReleaseName))
+	}
 	return nil
 }
 

--- a/service/chartconfig/v1/resource/chart/delete.go
+++ b/service/chartconfig/v1/resource/chart/delete.go
@@ -58,14 +58,14 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %s chart has to be deleted", desiredChartState.ChartName))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %s release has to be deleted", desiredChartState.ReleaseName))
 
-	if !reflect.DeepEqual(currentChartState, ChartState{}) && currentChartState.ChartName == desiredChartState.ChartName {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s chart needs to be deleted", desiredChartState.ChartName))
+	if !reflect.DeepEqual(currentChartState, ChartState{}) && currentChartState.ReleaseName == desiredChartState.ReleaseName {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s release needs to be deleted", desiredChartState.ReleaseName))
 
 		return &desiredChartState, nil
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s chart does not need to be deleted", desiredChartState.ChartName))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s release does not need to be deleted", desiredChartState.ReleaseName))
 	}
 
 	return nil, nil

--- a/service/chartconfig/v1/resource/chart/delete.go
+++ b/service/chartconfig/v1/resource/chart/delete.go
@@ -60,7 +60,7 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %s release has to be deleted", desiredChartState.ReleaseName))
 
-	if !reflect.DeepEqual(currentChartState, ChartState{}) && currentChartState.ReleaseName == desiredChartState.ReleaseName {
+	if !reflect.DeepEqual(currentChartState, ChartState{}) && reflect.DeepEqual(currentChartState, desiredChartState) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s release needs to be deleted", desiredChartState.ReleaseName))
 
 		return &desiredChartState, nil

--- a/service/chartconfig/v1/resource/chart/delete.go
+++ b/service/chartconfig/v1/resource/chart/delete.go
@@ -3,6 +3,7 @@ package chart
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/giantswarm/chart-operator/service/chartconfig/v1/key"
 	"github.com/giantswarm/microerror"
@@ -59,7 +60,7 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %s chart has to be deleted", desiredChartState.ChartName))
 
-	if currentChartState.ChartName != "" && currentChartState.ChartName == desiredChartState.ChartName {
+	if !reflect.DeepEqual(currentChartState, ChartState{}) && currentChartState.ChartName == desiredChartState.ChartName {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s chart needs to be deleted", desiredChartState.ChartName))
 
 		return &desiredChartState, nil

--- a/service/chartconfig/v1/resource/chart/delete_test.go
+++ b/service/chartconfig/v1/resource/chart/delete_test.go
@@ -36,39 +36,53 @@ func Test_Resource_Chart_newDeleteChange(t *testing.T) {
 			description:  "case 2: empty current, non-empty desired, expected empty",
 			currentState: &ChartState{},
 			desiredState: &ChartState{
-				ChartName: "desired",
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
 			},
 			expectedDeleteChange: nil,
 		},
 		{
 			description: "case 3: equal non-empty current and desired, expected desired",
 			currentState: &ChartState{
-				ChartName: "desired",
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
 			},
 			desiredState: &ChartState{
-				ChartName: "desired",
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
 			},
 			expectedDeleteChange: &ChartState{
-				ChartName: "desired",
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
 			},
 		},
 		{
 			description: "case 4: different non-empty current and desired, expected empty",
 			currentState: &ChartState{
-				ChartName: "current",
+				ChartName:      "current",
+				ReleaseName:    "current",
+				ReleaseVersion: "current",
 			},
 			desiredState: &ChartState{
-				ChartName: "desired",
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
 			},
 			expectedDeleteChange: nil,
 		},
 		{
-			description: "case 5: different same non-empty current and desired name, different version, expected empty",
+			description: "case 5: same non-empty current and desired name, different version, expected empty",
 			currentState: &ChartState{
+				ChartName:      "desired",
 				ReleaseName:    "desired",
 				ReleaseVersion: "current",
 			},
 			desiredState: &ChartState{
+				ChartName:      "desired",
 				ReleaseName:    "desired",
 				ReleaseVersion: "desired",
 			},

--- a/service/chartconfig/v1/resource/chart/delete_test.go
+++ b/service/chartconfig/v1/resource/chart/delete_test.go
@@ -1,0 +1,103 @@
+package chart
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Chart_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		obj                  v1alpha1.ChartConfig
+		currentState         *ChartState
+		desiredState         *ChartState
+		expectedDeleteChange *ChartState
+		description          string
+	}{
+		{
+			description:          "case 0: empty current and desired, expected empty",
+			currentState:         &ChartState{},
+			desiredState:         &ChartState{},
+			expectedDeleteChange: nil,
+		},
+		{
+			description: "case 1: non-empty current, empty desired, expected empty",
+			currentState: &ChartState{
+				ChartName: "current",
+			},
+			desiredState:         &ChartState{},
+			expectedDeleteChange: nil,
+		},
+
+		{
+			description:  "case 2: empty current, non-empty desired, expected empty",
+			currentState: &ChartState{},
+			desiredState: &ChartState{
+				ChartName: "desired",
+			},
+			expectedDeleteChange: nil,
+		},
+		{
+			description: "case 3: equal non-empty current and desired, expected desired",
+			currentState: &ChartState{
+				ChartName: "desired",
+			},
+			desiredState: &ChartState{
+				ChartName: "desired",
+			},
+			expectedDeleteChange: &ChartState{
+				ChartName: "desired",
+			},
+		},
+		{
+			description: "case 4: different non-empty current and desired, expected empty",
+			currentState: &ChartState{
+				ChartName: "current",
+			},
+			desiredState: &ChartState{
+				ChartName: "desired",
+			},
+			expectedDeleteChange: nil,
+		},
+	}
+
+	var newResource *Resource
+	var err error
+	{
+		c := Config{}
+		c.ApprClient = &apprMock{}
+		c.HelmClient = &helmMock{}
+		c.K8sClient = fake.NewSimpleClientset()
+		c.Logger = microloggertest.New()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			if tc.expectedDeleteChange == nil && result != nil {
+				t.Fatal("expected", nil, "got", result)
+			}
+			if result != nil {
+				deleteChange, ok := result.(*ChartState)
+				if !ok {
+					t.Fatalf("expected '%T', got '%T'", deleteChange, result)
+				}
+				if deleteChange.ChartName != "" && deleteChange.ChartName != tc.expectedDeleteChange.ChartName {
+					t.Fatalf("expected %s, got %s", tc.expectedDeleteChange, deleteChange.ChartName)
+				}
+			}
+		})
+	}
+
+}

--- a/service/chartconfig/v1/resource/chart/delete_test.go
+++ b/service/chartconfig/v1/resource/chart/delete_test.go
@@ -62,6 +62,18 @@ func Test_Resource_Chart_newDeleteChange(t *testing.T) {
 			},
 			expectedDeleteChange: nil,
 		},
+		{
+			description: "case 5: different same non-empty current and desired name, different version, expected empty",
+			currentState: &ChartState{
+				ReleaseName:    "desired",
+				ReleaseVersion: "current",
+			},
+			desiredState: &ChartState{
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
+			},
+			expectedDeleteChange: nil,
+		},
 	}
 
 	var newResource *Resource


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902.

Implements the chart resource delete methods corresponding to #37.