### PR TITLE
Remove tarball files after create and update

### DIFF
--- a/service/chartconfig/v1/resource/chart/create.go
+++ b/service/chartconfig/v1/resource/chart/create.go
@@ -33,7 +33,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		defer func() {
 			err := os.Remove(tarballPath)
 			if err != nil {
-				r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %q failed: %v", tarballPath, err))
+				r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %q failed", tarballPath), "stack", fmt.Sprintf("%#v", err))
 			}
 		}()
 

--- a/service/chartconfig/v1/resource/chart/create.go
+++ b/service/chartconfig/v1/resource/chart/create.go
@@ -3,6 +3,7 @@ package chart
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/giantswarm/microerror"
 
@@ -29,6 +30,12 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		if err != nil {
 			return microerror.Mask(err)
 		}
+		defer func() {
+			err := os.Remove(tarballPath)
+			if err != nil {
+				r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %q failed: %v", tarballPath, err))
+			}
+		}()
 
 		err = r.helmClient.InstallFromTarball(tarballPath, ns)
 		if err != nil {

--- a/service/chartconfig/v1/resource/chart/update.go
+++ b/service/chartconfig/v1/resource/chart/update.go
@@ -3,10 +3,12 @@ package chart
 import (
 	"context"
 	"fmt"
+	"os"
 
-	"github.com/giantswarm/chart-operator/service/chartconfig/v1/key"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
+
+	"github.com/giantswarm/chart-operator/service/chartconfig/v1/key"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
@@ -31,6 +33,12 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		if err != nil {
 			return microerror.Mask(err)
 		}
+		defer func() {
+			err := os.Remove(tarballPath)
+			if err != nil {
+				r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %q failed: %v", tarballPath, err))
+			}
+		}()
 
 		err = r.helmClient.UpdateReleaseFromTarball(releaseName, tarballPath)
 		if err != nil {

--- a/service/chartconfig/v1/resource/chart/update.go
+++ b/service/chartconfig/v1/resource/chart/update.go
@@ -36,7 +36,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		defer func() {
 			err := os.Remove(tarballPath)
 			if err != nil {
-				r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %q failed: %v", tarballPath, err))
+				r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %q failed", tarballPath), "stack", fmt.Sprintf("%#v", err))
 			}
 		}()
 


### PR DESCRIPTION
Defers the deletion of a downloaded tarball on update and create to prevent storing unneeded files. Also checks for an eventual deletion error and logs the fact.