### PR TITLE
Use correct RESTClient in controller config

### DIFF
--- a/service/controller/chart.go
+++ b/service/controller/chart.go
@@ -97,7 +97,7 @@ func NewChart(config ChartConfig) (*Chart, error) {
 			Informer:       newInformer,
 			Logger:         config.Logger,
 			ResourceRouter: resourceRouter,
-			RESTClient:     config.K8sClient.CoreV1().RESTClient(),
+			RESTClient:     config.G8sClient.CoreV1alpha1().RESTClient(),
 
 			Name: config.ProjectName + chartControllerSuffix,
 		}


### PR DESCRIPTION
This most likely caused Integration tests to fail, no clue how they could have ever worked TBH.

Might be worth a try to check if we reuse envs between tests which caused this flakyness.

Explanation can be found here: https://github.com/giantswarm/operatorkit/blob/1ddbbec19f4b9a9f8f942cb9313fc273e2a6a63c/controller/controller.go#L47