### PR TITLE
Add e2e test for chart deletion

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.1.2
+version: 0.1.3

--- a/integration/test/basic/basic_test.go
+++ b/integration/test/basic/basic_test.go
@@ -16,6 +16,8 @@ import (
 
 func TestChartLifecycle(t *testing.T) {
 	const release = "tb-release"
+
+	log.Println("creating test chart CR")
 	err := f.InstallResource("chart-operator-resource", templates.ChartOperatorResourceValues, ":stable")
 	if err != nil {
 		t.Fatalf("could not install chart-operator-resource-chart %v", err)
@@ -25,7 +27,9 @@ func TestChartLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal("could not get release status", err)
 	}
+	log.Println("test chart succesfully deployed")
 
+	log.Println("deleting test chart CR")
 	err = helmClient.DeleteRelease(release)
 	if err != nil {
 		t.Fatalf("could not delete chart-operator-resource-chart %v", err)
@@ -35,6 +39,7 @@ func TestChartLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal("could not get release status", err)
 	}
+	log.Println("test chart succesfully deleted")
 }
 
 func waitForReleaseStatus(helmClient *helmclient.Client, release string, status string) error {

--- a/integration/test/basic/basic_test.go
+++ b/integration/test/basic/basic_test.go
@@ -15,29 +15,29 @@ import (
 )
 
 func TestChartLifecycle(t *testing.T) {
-	const release = "tb-release"
+	const testRelease = "tb-release"
+	const cr = "chart-operator-resource"
 
 	log.Println("creating test chart CR")
-	err := f.InstallResource("chart-operator-resource", templates.ChartOperatorResourceValues, ":stable")
+	err := f.InstallResource(cr, templates.ChartOperatorResourceValues, ":stable")
 	if err != nil {
-		t.Fatalf("could not install chart-operator-resource-chart %v", err)
+		t.Fatalf("could not install %q %v", cr, err)
 	}
 
-	err = waitForReleaseStatus(helmClient, release, "DEPLOYED")
+	err = waitForReleaseStatus(helmClient, testRelease, "DEPLOYED")
 	if err != nil {
-		t.Fatal("could not get release status", err)
+		t.Fatalf("could not get release status of %q %v", testRelease, err)
 	}
 	log.Println("test chart succesfully deployed")
 
-	log.Println("deleting test chart CR")
-	err = helmClient.DeleteRelease(release)
+	err = helmClient.DeleteRelease(cr)
 	if err != nil {
-		t.Fatalf("could not delete chart-operator-resource-chart %v", err)
+		t.Fatalf("could not delete %q %v", cr, err)
 	}
 
-	err = waitForReleaseStatus(helmClient, release, "DELETED")
+	err = waitForReleaseStatus(helmClient, testRelease, "DELETED")
 	if err != nil {
-		t.Fatal("could not get release status", err)
+		t.Fatalf("could not get release status of %q %v", testRelease, err)
 	}
 	log.Println("test chart succesfully deleted")
 }

--- a/service/controller/v1/resource/chart/delete.go
+++ b/service/controller/v1/resource/chart/delete.go
@@ -23,8 +23,9 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	if chartState.ReleaseName != "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %s", chartState.ReleaseName))
 		release := key.ReleaseName(customObject)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting custom object release %s", release))
 
-		err := r.helmClient.DeleteRelease(release)
+		err := r.helmClient.DeleteRelease(chartState.ReleaseName)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/v1/resource/chart/delete.go
+++ b/service/controller/v1/resource/chart/delete.go
@@ -5,16 +5,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/giantswarm/chart-operator/service/controller/v1/key"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
-	customObject, err := key.ToCustomObject(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
 	chartState, err := toChartState(deleteChange)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/v1/resource/chart/delete.go
+++ b/service/controller/v1/resource/chart/delete.go
@@ -22,8 +22,6 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 
 	if chartState.ReleaseName != "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %s", chartState.ReleaseName))
-		release := key.ReleaseName(customObject)
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting custom object release %s", release))
 
 		err := r.helmClient.DeleteRelease(chartState.ReleaseName)
 		if err != nil {

--- a/service/controller/v1/resource/chart/delete.go
+++ b/service/controller/v1/resource/chart/delete.go
@@ -61,7 +61,7 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %s release has to be deleted", desiredChartState.ReleaseName))
 
-	if !reflect.DeepEqual(currentChartState, ChartState{}) && reflect.DeepEqual(currentChartState, desiredChartState) {
+	if !reflect.DeepEqual(currentChartState, ChartState{}) && currentChartState.ReleaseName == desiredChartState.ReleaseName && currentChartState.ReleaseVersion == desiredChartState.ReleaseVersion {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s release needs to be deleted", desiredChartState.ReleaseName))
 
 		return &desiredChartState, nil

--- a/service/controller/v1/resource/chart/delete_test.go
+++ b/service/controller/v1/resource/chart/delete_test.go
@@ -27,7 +27,7 @@ func Test_Resource_Chart_newDeleteChange(t *testing.T) {
 		{
 			description: "case 1: non-empty current, empty desired, expected empty",
 			currentState: &ChartState{
-				ChartName: "current",
+				ReleaseName: "current",
 			},
 			desiredState:         &ChartState{},
 			expectedDeleteChange: nil,

--- a/service/controller/v1/resource/chart/update.go
+++ b/service/controller/v1/resource/chart/update.go
@@ -46,7 +46,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart %s", chartState.ChartName))
 
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %s do not need to be updated", chartState.ChartName))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %s does not need to be updated", chartState.ChartName))
 	}
 	return nil
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902.

Add deletion of a chart to a lifecycle test. Also provides a fix for (before failing) test in the resource deletion method.