### PR TITLE
Move chart-operator (-resources) to giantswarm namespace

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.1.2
+version: 0.1.3

--- a/helm/chart-operator-chart/README.md
+++ b/helm/chart-operator-chart/README.md
@@ -6,7 +6,7 @@ Helm Chart for the chart-operator
 | Parameter          | Description                                 | Default                                                           |
 |--------------------|---------------------------------------------|-------------------------------------------------------------------|
 | `name`             | The name of the operator                    | `chart-operator`                                                  |
-| `namespace`        | The namespaces of the operator              | `kube-system`                                                     |
+| `namespace`        | The namespaces of the operator              | `giantswarm`                                                     |
 | `port`             | The port of the operator container          | `8000`                                                            |
 | `image.repository` | The operator container image repository     | `quay.io/giantswarm/chart-operator`                               |
 | `image.tag`        | The operator container image tag            | `[latest commit SHA]`                                             |

--- a/helm/chart-operator-chart/templates/configmap.yaml
+++ b/helm/chart-operator-chart/templates/configmap.yaml
@@ -17,4 +17,4 @@ data:
       kubernetes:
         incluster: true
         watch:
-          namespace: 'kube-system'
+          namespace: '{{ .Values.namespace }}'

--- a/helm/chart-operator-chart/values.yaml
+++ b/helm/chart-operator-chart/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 name: chart-operator
-namespace: kube-system
+namespace: giantswarm
 port: 8000
 
 replicas: 1

--- a/helm/chart-operator-resource-chart/templates/chartconfig.yaml
+++ b/helm/chart-operator-resource-chart/templates/chartconfig.yaml
@@ -1,13 +1,13 @@
 apiVersion: "core.giantswarm.io/v1alpha1"
 kind: ChartConfig
 metadata:
-  name: "{{.Values.chart.name}}"
-  namespace: "kube-system"
+  name: "{{ .Values.chart.name }}"
+  namespace: "{{ .Values.namespace }}"
 spec:
   chart:
-    channel: "{{.Values.chart.channel}}"
-    name: "{{.Values.chart.name}}"
-    namespace: "{{.Values.chart.namespace}}"
-    release: "{{.Values.chart.release}}"
+    channel: "{{ .Values.chart.channel }}"
+    name: "{{ .Values.chart.name }}"
+    namespace: "{{ .Values.chart.namespace }}"
+    release: "{{ .Values.chart.release }}"
   versionBundle:
-    version: "{{.Values.versionBundleVersion}}"
+    version: "{{ .Values.versionBundleVersion }}"

--- a/helm/chart-operator-resource-chart/values.yaml
+++ b/helm/chart-operator-resource-chart/values.yaml
@@ -4,4 +4,5 @@ chart:
   namespace: "default"
   release: "0.2.0"
 
+namespace: "giantswarm"
 versionBundleVersion: "0.1.0"

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -114,7 +114,7 @@ func installCNR(f *framework.Host, helmClient *helmclient.Client) error {
 		return microerror.Mask(err)
 	}
 
-	err = helmClient.InstallFromTarball(tarball, "kube-system",
+	err = helmClient.InstallFromTarball(tarball, "giantswarm",
 		helm.ReleaseName("cnr-server"),
 		helm.ValueOverrides([]byte("{}")),
 		helm.InstallWait(true))
@@ -135,13 +135,13 @@ func installInitialCharts(f *framework.Host) error {
 		return microerror.Mask(err)
 	}
 
-	podName, err := waitForPod(f, "kube-system", "app=cnr-server")
+	podName, err := waitForPod(f, "giantswarm", "app=cnr-server")
 	if err != nil {
 		return microerror.Mask(err)
 	}
 	tc := k8sportforward.TunnelConfig{
 		Remote:    5000,
-		Namespace: "kube-system",
+		Namespace: "giantswarm",
 		PodName:   podName,
 	}
 	tunnel, err := fw.ForwardPort(tc)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/1902.
Regarding #64.

Since our own tiller will live in the `giantswarm`namespace, `chart-operator` and its resources should do too.