### PR TITLE
Add pipeline step for publishing to stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,19 @@ jobs:
 
     - run: ./architect deploy
 
-    - run: ./architect publish
+    - run:
+        name: publish to beta
+        command: ./architect publish
+
+  publish_to_stable:
+    machine: true
+    steps:
+    - checkout
+
+    - attach_workspace:
+        at: .
+
+    - run: ./architect publish --stable
 
 workflows:
   version: 2
@@ -90,3 +102,10 @@ workflows:
               only: master
           requires:
           - e2eTestMaster
+
+      - publish_to_stable:
+          filters:
+            branches:
+              only: master
+          requires:
+          - deploy


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902

Requires https://github.com/giantswarm/architect/pull/222. Currently it just promotes to stable, we can extend the pipeline with additional intermediate steps (more specific e2e testing and/or hold before final promotion for instance).