### PR TITLE
remove InstallWait from create chart code

### DIFF
--- a/service/controller/v2/resource/chart/create.go
+++ b/service/controller/v2/resource/chart/create.go
@@ -59,8 +59,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		//
 		err = r.helmClient.InstallFromTarball(tarballPath, ns,
 			helm.ReleaseName(chartState.ReleaseName),
-			helm.ValueOverrides(values),
-			helm.InstallWait(true))
+			helm.ValueOverrides(values))
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/chart-operator/issues/73

No need to wait for chart installed, the operator can send the installation request to tiller and continue.