### PR TITLE
Fixed registry for chart-operator-chart

### DIFF
--- a/helm/chart-operator-chart/templates/deployment.yaml
+++ b/helm/chart-operator-chart/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: {{ .Values.name }}
       containers:
       - name: {{ .Values.name }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "quay.io/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         volumeMounts:
         - name: {{ .Values.name }}
           mountPath: /var/run/{{ .Values.name }}/configmap/


### PR DESCRIPTION
Uses quay.io as the registry for chart-operator, even though it is installed as a chart by cluster-operator, the build process is still dependent on quay.io.