### PR TITLE
opsctl: copy v2 to v3

### DIFF
--- a/service/controller/v3/error.go
+++ b/service/controller/v3/error.go
@@ -1,0 +1,10 @@
+package v2
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v3/key/error.go
+++ b/service/controller/v3/key/error.go
@@ -1,0 +1,17 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+var emptyValueError = microerror.New("empty value")
+
+// IsEmptyValueError asserts emptyValueError.
+func IsEmptyValueError(err error) bool {
+	return microerror.Cause(err) == emptyValueError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v3/key/key.go
+++ b/service/controller/v3/key/key.go
@@ -1,0 +1,49 @@
+package key
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+)
+
+func ChartName(customObject v1alpha1.ChartConfig) string {
+	return customObject.Spec.Chart.Name
+}
+
+func ChannelName(customObject v1alpha1.ChartConfig) string {
+	return customObject.Spec.Chart.Channel
+}
+
+func ConfigMapName(customObject v1alpha1.ChartConfig) string {
+	return customObject.Spec.Chart.ConfigMap.Name
+}
+
+func ConfigMapNamespace(customObject v1alpha1.ChartConfig) string {
+	return customObject.Spec.Chart.ConfigMap.Namespace
+}
+
+func Namespace(customObject v1alpha1.ChartConfig) string {
+	return customObject.Spec.Chart.Namespace
+}
+
+func ReleaseName(customObject v1alpha1.ChartConfig) string {
+	return customObject.Spec.Chart.Release
+}
+
+// ToCustomObject converts value to v1alpha1.ChartConfig and returns it or error
+// if type does not match.
+func ToCustomObject(v interface{}) (v1alpha1.ChartConfig, error) {
+	customObjectPointer, ok := v.(*v1alpha1.ChartConfig)
+	if !ok {
+		return v1alpha1.ChartConfig{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.ChartConfig{}, v)
+	}
+
+	if customObjectPointer == nil {
+		return v1alpha1.ChartConfig{}, microerror.Maskf(emptyValueError, "empty value cannot be converted to CustomObject")
+	}
+
+	return *customObjectPointer, nil
+}
+
+func VersionBundleVersion(customObject v1alpha1.ChartConfig) string {
+	return customObject.Spec.VersionBundle.Version
+}

--- a/service/controller/v3/key/key_test.go
+++ b/service/controller/v3/key/key_test.go
@@ -1,0 +1,177 @@
+package key
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+)
+
+func Test_ChartName(t *testing.T) {
+	expectedName := "chart-operator-chart"
+
+	obj := v1alpha1.ChartConfig{
+		Spec: v1alpha1.ChartConfigSpec{
+			Chart: v1alpha1.ChartConfigSpecChart{
+				Name:    "chart-operator-chart",
+				Channel: "0.1-beta",
+				Release: "chart-operator",
+			},
+		},
+	}
+
+	if ChartName(obj) != expectedName {
+		t.Fatalf("chart name %s, want %s", ChartName(obj), expectedName)
+	}
+}
+
+func Test_ChannelName(t *testing.T) {
+	expectedChannel := "0.1-beta"
+
+	obj := v1alpha1.ChartConfig{
+		Spec: v1alpha1.ChartConfigSpec{
+			Chart: v1alpha1.ChartConfigSpecChart{
+				Name:    "chart-operator-chart",
+				Channel: "0.1-beta",
+				Release: "chart-operator",
+			},
+		},
+	}
+
+	if ChannelName(obj) != expectedChannel {
+		t.Fatalf("channel name %s, want %s", ChannelName(obj), expectedChannel)
+	}
+}
+
+func Test_ConfigMapName(t *testing.T) {
+	expectedConfigMapName := "chart-operator-chart-values"
+
+	obj := v1alpha1.ChartConfig{
+		Spec: v1alpha1.ChartConfigSpec{
+			Chart: v1alpha1.ChartConfigSpecChart{
+				Name:    "chart-operator-chart",
+				Channel: "0.1-beta",
+				ConfigMap: v1alpha1.ChartConfigSpecConfigMap{
+					Name:      "chart-operator-chart-values",
+					Namespace: "giantswarm",
+				},
+				Release: "chart-operator",
+			},
+		},
+	}
+
+	if ConfigMapName(obj) != expectedConfigMapName {
+		t.Fatalf("config map name %s, want %s", ConfigMapName(obj), expectedConfigMapName)
+	}
+}
+
+func Test_ConfigMapNamespace(t *testing.T) {
+	expectedConfigMapNamespace := "giantswarm"
+
+	obj := v1alpha1.ChartConfig{
+		Spec: v1alpha1.ChartConfigSpec{
+			Chart: v1alpha1.ChartConfigSpecChart{
+				Name:    "chart-operator-chart",
+				Channel: "0.1-beta",
+				ConfigMap: v1alpha1.ChartConfigSpecConfigMap{
+					Name:      "chart-operator-chart-values",
+					Namespace: "giantswarm",
+				},
+				Release: "chart-operator",
+			},
+		},
+	}
+
+	if ConfigMapNamespace(obj) != expectedConfigMapNamespace {
+		t.Fatalf("config map namespace %s, want %s", ConfigMapNamespace(obj), expectedConfigMapNamespace)
+	}
+}
+
+func Test_Namespace(t *testing.T) {
+	expected := "giantswarm"
+
+	obj := v1alpha1.ChartConfig{
+		Spec: v1alpha1.ChartConfigSpec{
+			Chart: v1alpha1.ChartConfigSpecChart{
+				Namespace: "giantswarm",
+			},
+		},
+	}
+
+	actual := Namespace(obj)
+	if actual != expected {
+		t.Fatalf("namespace %s, want %s", actual, expected)
+	}
+}
+
+func Test_ReleaseName(t *testing.T) {
+	expectedRelease := "chart-operator"
+
+	obj := v1alpha1.ChartConfig{
+		Spec: v1alpha1.ChartConfigSpec{
+			Chart: v1alpha1.ChartConfigSpecChart{
+				Name:    "chart-operator-chart",
+				Channel: "0.1-beta",
+				Release: "chart-operator",
+			},
+		},
+	}
+
+	if ReleaseName(obj) != expectedRelease {
+		t.Fatalf("release name %s, want %s", ReleaseName(obj), expectedRelease)
+	}
+}
+
+func Test_ToCustomObject(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          interface{}
+		expectedObject v1alpha1.ChartConfig
+		errorMatcher   func(error) bool
+	}{
+		{
+			name: "case 0: basic match",
+			input: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name:    "chart-operator-chart",
+						Channel: "0.1-beta",
+						Release: "chart-operator",
+					},
+				},
+			},
+			expectedObject: v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name:    "chart-operator-chart",
+						Channel: "0.1-beta",
+						Release: "chart-operator",
+					},
+				},
+			},
+		},
+		{
+			name:         "case 1: wrong type",
+			input:        &v1alpha1.CertConfig{},
+			errorMatcher: IsWrongTypeError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ToCustomObject(tc.input)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedObject) {
+				t.Fatalf("Custom Object == %q, want %q", result, tc.expectedObject)
+			}
+		})
+	}
+}

--- a/service/controller/v3/resource/chart/create.go
+++ b/service/controller/v3/resource/chart/create.go
@@ -1,0 +1,97 @@
+package chart
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/helm/pkg/helm"
+
+	"github.com/giantswarm/chart-operator/service/controller/v2/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	chartState, err := toChartState(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if chartState.ChartName != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart %s", chartState.ChartName))
+		name := key.ChartName(customObject)
+		channel := key.ChannelName(customObject)
+		ns := key.Namespace(customObject)
+
+		tarballPath, err := r.apprClient.PullChartTarball(name, channel)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		defer func() {
+			err := r.fs.Remove(tarballPath)
+			if err != nil {
+				r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %q failed", tarballPath), "stack", fmt.Sprintf("%#v", err))
+			}
+		}()
+
+		err = r.helmClient.EnsureTillerInstalled()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		values, err := json.Marshal(chartState.ChartValues)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		// We need to pass the ValueOverrides option to make the install process
+		// use the default values and prevent errors on nested values.
+		//
+		//     {
+		//      rpc error: code = Unknown desc = render error in "cnr-server-chart/templates/deployment.yaml":
+		//      template: cnr-server-chart/templates/deployment.yaml:20:26:
+		//      executing "cnr-server-chart/templates/deployment.yaml" at <.Values.image.reposi...>: can't evaluate field repository in type interface {}
+		//     }
+		//
+		err = r.helmClient.InstallFromTarball(tarballPath, ns,
+			helm.ReleaseName(chartState.ReleaseName),
+			helm.ValueOverrides(values))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart %s", chartState.ChartName))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not creating chart %s", chartState.ChartName))
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentChartState, err := toChartState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredChartState, err := toChartState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %s chart has to be created", desiredChartState.ChartName))
+
+	createState := &ChartState{}
+
+	if currentChartState.ChartName == "" || desiredChartState.ChartName != currentChartState.ChartName {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s chart needs to be created", desiredChartState.ChartName))
+
+		createState = &desiredChartState
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s chart does not need to be created", desiredChartState.ChartName))
+	}
+
+	return createState, nil
+}

--- a/service/controller/v3/resource/chart/create_test.go
+++ b/service/controller/v3/resource/chart/create_test.go
@@ -1,0 +1,98 @@
+package chart
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Chart_newCreate(t *testing.T) {
+	testCases := []struct {
+		obj               v1alpha1.ChartConfig
+		currentState      *ChartState
+		desiredState      *ChartState
+		expectedChartName string
+		description       string
+	}{
+		{
+			description:       "empty current and desired, expected empty",
+			currentState:      &ChartState{},
+			desiredState:      &ChartState{},
+			expectedChartName: "",
+		},
+		{
+			description: "non-empty current, empty desired, expected empty",
+			currentState: &ChartState{
+				ChartName: "current",
+			},
+			desiredState:      &ChartState{},
+			expectedChartName: "",
+		},
+
+		{
+			description:  "empty current, non-empty desired, expected desired",
+			currentState: &ChartState{},
+			desiredState: &ChartState{
+				ChartName: "desired",
+			},
+			expectedChartName: "desired",
+		},
+		{
+			description: "equal non-empty current and desired, expected desired",
+			currentState: &ChartState{
+				ChartName: "desired",
+			},
+			desiredState: &ChartState{
+				ChartName: "desired",
+			},
+			expectedChartName: "desired",
+		},
+		{
+			description: "different non-empty current and desired, expected desired",
+			currentState: &ChartState{
+				ChartName: "current",
+			},
+			desiredState: &ChartState{
+				ChartName: "desired",
+			},
+			expectedChartName: "desired",
+		},
+	}
+
+	var newResource *Resource
+	var err error
+	{
+		c := Config{}
+		c.ApprClient = &apprMock{}
+		c.Fs = afero.NewMemMapFs()
+		c.HelmClient = &helmMock{}
+		c.K8sClient = fake.NewSimpleClientset()
+		c.Logger = microloggertest.New()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			createChange, ok := result.(*ChartState)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", createChange, result)
+			}
+			if createChange.ChartName != "" && createChange.ChartName != tc.expectedChartName {
+				t.Fatalf("expected %s, got %s", tc.expectedChartName, createChange.ChartName)
+			}
+		})
+	}
+
+}

--- a/service/controller/v3/resource/chart/current.go
+++ b/service/controller/v3/resource/chart/current.go
@@ -1,0 +1,47 @@
+package chart
+
+import (
+	"context"
+
+	"github.com/giantswarm/helmclient"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/chart-operator/service/controller/v2/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	err = r.helmClient.EnsureTillerInstalled()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	releaseName := key.ReleaseName(customObject)
+	releaseContent, err := r.helmClient.GetReleaseContent(releaseName)
+	if helmclient.IsReleaseNotFound(err) {
+		// Return early as release is not installed.
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	releaseHistory, err := r.helmClient.GetReleaseHistory(releaseName)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	chartState := &ChartState{
+		ChartName:      key.ChartName(customObject),
+		ChannelName:    key.ChannelName(customObject),
+		ReleaseName:    releaseName,
+		ChartValues:    releaseContent.Values,
+		ReleaseStatus:  releaseContent.Status,
+		ReleaseVersion: releaseHistory.Version,
+	}
+
+	return chartState, nil
+}

--- a/service/controller/v3/resource/chart/current_test.go
+++ b/service/controller/v3/resource/chart/current_test.go
@@ -1,0 +1,165 @@
+package chart
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/helmclient"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_CurrentState(t *testing.T) {
+	testCases := []struct {
+		name           string
+		obj            *v1alpha1.ChartConfig
+		releaseContent *helmclient.ReleaseContent
+		releaseHistory *helmclient.ReleaseHistory
+		returnedError  error
+		expectedState  ChartState
+		expectedError  bool
+	}{
+		{
+			name: "case 0: basic match",
+			obj: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name:    "quay.io/giantswarm/chart-operator-chart",
+						Channel: "0.1-beta",
+						Release: "chart-operator",
+					},
+				},
+			},
+			releaseContent: &helmclient.ReleaseContent{
+				Name:   "chart-operator",
+				Status: "DEPLOYED",
+				Values: map[string]interface{}{
+					"key": "value",
+				},
+			},
+			releaseHistory: &helmclient.ReleaseHistory{
+				Name:    "chart-operator",
+				Version: "0.1.2",
+			},
+			expectedState: ChartState{
+				ChartName: "quay.io/giantswarm/chart-operator-chart",
+				ChartValues: map[string]interface{}{
+					"key": "value",
+				},
+				ChannelName:    "0.1-beta",
+				ReleaseName:    "chart-operator",
+				ReleaseStatus:  "DEPLOYED",
+				ReleaseVersion: "0.1.2",
+			},
+		},
+		{
+			name: "case 1: different values",
+			obj: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name:    "quay.io/giantswarm/chart-operator-chart",
+						Channel: "0.1-beta",
+						Release: "chart-operator",
+					},
+				},
+			},
+			releaseContent: &helmclient.ReleaseContent{
+				Name:   "chart-operator",
+				Status: "FAILED",
+				Values: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			releaseHistory: &helmclient.ReleaseHistory{
+				Name:    "chart-operator",
+				Version: "0.1.3",
+			},
+			expectedState: ChartState{
+				ChartName: "quay.io/giantswarm/chart-operator-chart",
+				ChartValues: map[string]interface{}{
+					"foo": "bar",
+				},
+				ChannelName:    "0.1-beta",
+				ReleaseName:    "chart-operator",
+				ReleaseStatus:  "FAILED",
+				ReleaseVersion: "0.1.3",
+			},
+		},
+		{
+			name: "case 2: empty state when error for no release present",
+			obj: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name:    "quay.io/giantswarm/chart-operator-chart",
+						Channel: "0.1-beta",
+						Release: "missing-operator",
+					},
+				},
+			},
+			releaseContent: &helmclient.ReleaseContent{},
+			releaseHistory: &helmclient.ReleaseHistory{},
+			returnedError:  fmt.Errorf("No such release: missing-operator"),
+		},
+		{
+			name: "case 3: unexpected error",
+			obj: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name:    "quay.io/giantswarm/chart-operator-chart",
+						Channel: "0.1-beta",
+						Release: "missing-operator",
+					},
+				},
+			},
+			releaseContent: &helmclient.ReleaseContent{},
+			releaseHistory: &helmclient.ReleaseHistory{},
+			returnedError:  fmt.Errorf("Unexpected error"),
+			expectedError:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			helmClient := &helmMock{
+				defaultReleaseContent: tc.releaseContent,
+				defaultReleaseHistory: tc.releaseHistory,
+				defaultError:          tc.returnedError,
+			}
+
+			c := Config{
+				ApprClient: &apprMock{},
+				Fs:         afero.NewMemMapFs(),
+				HelmClient: helmClient,
+				K8sClient:  fake.NewSimpleClientset(),
+				Logger:     microloggertest.New(),
+			}
+
+			r, err := New(c)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			result, err := r.GetCurrentState(context.TODO(), tc.obj)
+			switch {
+			case err != nil && !tc.expectedError:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.expectedError:
+				t.Fatalf("error == nil, want non-nil")
+			}
+
+			chartState, err := toChartState(result)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			if !reflect.DeepEqual(chartState, tc.expectedState) {
+				t.Fatalf("ChartState == %q, want %q", chartState, tc.expectedState)
+			}
+		})
+	}
+
+}

--- a/service/controller/v3/resource/chart/delete.go
+++ b/service/controller/v3/resource/chart/delete.go
@@ -1,0 +1,72 @@
+package chart
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/helm/pkg/helm"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	chartState, err := toChartState(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if chartState.ReleaseName != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %s", chartState.ReleaseName))
+
+		err := r.helmClient.EnsureTillerInstalled()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = r.helmClient.DeleteRelease(chartState.ReleaseName, helm.DeletePurge(true))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %s", chartState.ReleaseName))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting release %s", chartState.ReleaseName))
+	}
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentChartState, err := toChartState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredChartState, err := toChartState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %s release has to be deleted", desiredChartState.ReleaseName))
+
+	if !currentChartState.IsEmpty() && currentChartState.Equals(desiredChartState) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s release needs to be deleted", desiredChartState.ReleaseName))
+
+		return &desiredChartState, nil
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %s release does not need to be deleted", desiredChartState.ReleaseName))
+	}
+
+	return nil, nil
+}

--- a/service/controller/v3/resource/chart/delete_test.go
+++ b/service/controller/v3/resource/chart/delete_test.go
@@ -1,0 +1,131 @@
+package chart
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Chart_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		obj                  v1alpha1.ChartConfig
+		currentState         *ChartState
+		desiredState         *ChartState
+		expectedDeleteChange *ChartState
+		description          string
+	}{
+		{
+			description:          "case 0: empty current and desired, expected empty",
+			currentState:         &ChartState{},
+			desiredState:         &ChartState{},
+			expectedDeleteChange: nil,
+		},
+		{
+			description: "case 1: non-empty current, empty desired, expected empty",
+			currentState: &ChartState{
+				ChartName: "current",
+			},
+			desiredState:         &ChartState{},
+			expectedDeleteChange: nil,
+		},
+
+		{
+			description:  "case 2: empty current, non-empty desired, expected empty",
+			currentState: &ChartState{},
+			desiredState: &ChartState{
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
+			},
+			expectedDeleteChange: nil,
+		},
+		{
+			description: "case 3: equal non-empty current and desired, expected desired",
+			currentState: &ChartState{
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
+			},
+			desiredState: &ChartState{
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
+			},
+			expectedDeleteChange: &ChartState{
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
+			},
+		},
+		{
+			description: "case 4: different non-empty current and desired, expected empty",
+			currentState: &ChartState{
+				ChartName:      "current",
+				ReleaseName:    "current",
+				ReleaseVersion: "current",
+			},
+			desiredState: &ChartState{
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
+			},
+			expectedDeleteChange: nil,
+		},
+		{
+			description: "case 5: same non-empty current and desired name, different version, expected empty",
+			currentState: &ChartState{
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "current",
+			},
+			desiredState: &ChartState{
+				ChartName:      "desired",
+				ReleaseName:    "desired",
+				ReleaseVersion: "desired",
+			},
+			expectedDeleteChange: nil,
+		},
+	}
+
+	var newResource *Resource
+	var err error
+	{
+		c := Config{}
+		c.ApprClient = &apprMock{}
+		c.Fs = afero.NewMemMapFs()
+		c.HelmClient = &helmMock{}
+		c.K8sClient = fake.NewSimpleClientset()
+		c.Logger = microloggertest.New()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			if tc.expectedDeleteChange == nil && result != nil {
+				t.Fatal("expected", nil, "got", result)
+			}
+			if result != nil {
+				deleteChange, ok := result.(*ChartState)
+				if !ok {
+					t.Fatalf("expected '%T', got '%T'", deleteChange, result)
+				}
+				if deleteChange.ChartName != "" && deleteChange.ChartName != tc.expectedDeleteChange.ChartName {
+					t.Fatalf("expected %s, got %s", tc.expectedDeleteChange, deleteChange.ChartName)
+				}
+			}
+		})
+	}
+
+}

--- a/service/controller/v3/resource/chart/desired.go
+++ b/service/controller/v3/resource/chart/desired.go
@@ -1,0 +1,67 @@
+package chart
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/chart-operator/service/controller/v2/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	name := key.ChartName(customObject)
+	channel := key.ChannelName(customObject)
+	chartValues, err := r.getConfigMapValues(ctx, customObject)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	releaseVersion, err := r.apprClient.GetReleaseVersion(name, channel)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	chartState := &ChartState{
+		ChartName:      key.ChartName(customObject),
+		ChartValues:    chartValues,
+		ChannelName:    key.ChannelName(customObject),
+		ReleaseName:    key.ReleaseName(customObject),
+		ReleaseVersion: releaseVersion,
+	}
+
+	return chartState, nil
+}
+
+func (r *Resource) getConfigMapValues(ctx context.Context, customObject v1alpha1.ChartConfig) (map[string]interface{}, error) {
+	chartValues := make(map[string]interface{})
+
+	if key.ConfigMapName(customObject) != "" {
+		configMapName := key.ConfigMapName(customObject)
+		configMapNamespace := key.ConfigMapNamespace(customObject)
+
+		configMap, err := r.k8sClient.CoreV1().ConfigMaps(configMapNamespace).Get(configMapName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return chartValues, microerror.Maskf(notFoundError, "config map '%s' in namespace '%s' not found", configMapName, configMapNamespace)
+		} else if err != nil {
+			return chartValues, microerror.Mask(err)
+		}
+
+		jsonData := configMap.Data["values.json"]
+		if jsonData != "" {
+			err = json.Unmarshal([]byte(jsonData), &chartValues)
+			if err != nil {
+				return chartValues, microerror.Mask(err)
+			}
+		}
+	}
+
+	return chartValues, nil
+}

--- a/service/controller/v3/resource/chart/desired_test.go
+++ b/service/controller/v3/resource/chart/desired_test.go
@@ -1,0 +1,216 @@
+package chart
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/spf13/afero"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_DesiredState(t *testing.T) {
+	testCases := []struct {
+		name          string
+		obj           *v1alpha1.ChartConfig
+		configMap     *apiv1.ConfigMap
+		expectedState ChartState
+		errorMatcher  func(error) bool
+	}{
+		{
+			name: "case 0: basic match",
+			obj: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name:    "chart-operator-chart",
+						Channel: "0-1-beta",
+						Release: "chart-operator",
+					},
+				},
+			},
+			expectedState: ChartState{
+				ChartName:      "chart-operator-chart",
+				ChartValues:    map[string]interface{}{},
+				ChannelName:    "0-1-beta",
+				ReleaseName:    "chart-operator",
+				ReleaseVersion: "0.1.2",
+			},
+		},
+		{
+			name: "case 1: basic match with empty config map",
+			obj: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name: "chart-operator-chart",
+						ConfigMap: v1alpha1.ChartConfigSpecConfigMap{
+							Name:      "chart-operator-values-configmap",
+							Namespace: "giantswarm",
+						},
+						Channel: "0.1-beta",
+						Release: "chart-operator",
+					},
+				},
+			},
+			configMap: &apiv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "chart-operator-values-configmap",
+					Namespace: "giantswarm",
+				},
+				Data: map[string]string{},
+			},
+			expectedState: ChartState{
+				ChartName:      "chart-operator-chart",
+				ChartValues:    map[string]interface{}{},
+				ChannelName:    "0.1-beta",
+				ReleaseName:    "chart-operator",
+				ReleaseVersion: "0.1.2",
+			},
+		},
+		{
+			name: "case 2: basic match with config map value",
+			obj: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name: "chart-operator-chart",
+						ConfigMap: v1alpha1.ChartConfigSpecConfigMap{
+							Name:      "chart-operator-values-configmap",
+							Namespace: "giantswarm",
+						},
+						Channel: "0-1-beta",
+						Release: "chart-operator",
+					},
+				},
+			},
+			configMap: &apiv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "chart-operator-values-configmap",
+					Namespace: "giantswarm",
+				},
+				Data: map[string]string{
+					"values.json": `{ "test": "test" }`,
+				},
+			},
+			expectedState: ChartState{
+				ChartName: "chart-operator-chart",
+				ChartValues: map[string]interface{}{
+					"test": "test",
+				},
+				ChannelName:    "0-1-beta",
+				ReleaseName:    "chart-operator",
+				ReleaseVersion: "0.1.2",
+			},
+		},
+		{
+			name: "case 3: config map with multiple values",
+			obj: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name: "chart-operator-chart",
+						ConfigMap: v1alpha1.ChartConfigSpecConfigMap{
+							Name:      "chart-operator-values-configmap",
+							Namespace: "giantswarm",
+						},
+						Channel: "0-1-beta",
+						Release: "chart-operator",
+					},
+				},
+			},
+			configMap: &apiv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "chart-operator-values-configmap",
+					Namespace: "giantswarm",
+				},
+				Data: map[string]string{
+					"values.json": `{ "provider": "azure", "replicas": 2 }`,
+				},
+			},
+			expectedState: ChartState{
+				ChartName: "chart-operator-chart",
+				ChartValues: map[string]interface{}{
+					"provider": "azure",
+					// Numeric values in JSON will be deserialized to a float64.
+					"replicas": float64(2),
+				},
+				ChannelName:    "0-1-beta",
+				ReleaseName:    "chart-operator",
+				ReleaseVersion: "0.1.2",
+			},
+		},
+		{
+			name: "case 4: config map not found",
+			obj: &v1alpha1.ChartConfig{
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name: "chart-operator-chart",
+						ConfigMap: v1alpha1.ChartConfigSpecConfigMap{
+							Name:      "chart-operator-values-configmap",
+							Namespace: "giantswarm",
+						},
+						Channel: "0-1-beta",
+						Release: "chart-operator",
+					},
+				},
+			},
+			configMap: &apiv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "missing-values-configmap",
+					Namespace: "giantswarm",
+				},
+			},
+			errorMatcher: IsNotFound,
+		},
+	}
+
+	apprClient := &apprMock{
+		defaultReleaseVersion: "0.1.2",
+	}
+	helmClient := &helmMock{
+		defaultError: nil,
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := make([]runtime.Object, 0, 0)
+			if tc.configMap != nil {
+				objs = append(objs, tc.configMap)
+			}
+
+			c := Config{
+				ApprClient: apprClient,
+				Fs:         afero.NewMemMapFs(),
+				HelmClient: helmClient,
+				K8sClient:  fake.NewSimpleClientset(objs...),
+				Logger:     microloggertest.New(),
+			}
+			r, err := New(c)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			result, err := r.GetDesiredState(context.TODO(), tc.obj)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			chartState, err := toChartState(result)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			if !reflect.DeepEqual(chartState, tc.expectedState) {
+				t.Fatalf("ChartState == %#v, want %#v", chartState, tc.expectedState)
+			}
+		})
+	}
+
+}

--- a/service/controller/v3/resource/chart/error.go
+++ b/service/controller/v3/resource/chart/error.go
@@ -1,0 +1,24 @@
+package chart
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v3/resource/chart/mock_test.go
+++ b/service/controller/v3/resource/chart/mock_test.go
@@ -1,0 +1,67 @@
+package chart
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/helmclient"
+	"k8s.io/helm/pkg/helm"
+)
+
+type apprMock struct {
+	defaultReleaseVersion string
+	defaultError          bool
+}
+
+func (a *apprMock) GetReleaseVersion(name, channel string) (string, error) {
+	if a.defaultError {
+		return "", fmt.Errorf("error getting default release")
+	}
+
+	return a.defaultReleaseVersion, nil
+}
+
+func (a *apprMock) PullChartTarball(name, channel string) (string, error) {
+	return "", nil
+}
+
+type helmMock struct {
+	defaultReleaseContent *helmclient.ReleaseContent
+	defaultReleaseHistory *helmclient.ReleaseHistory
+	defaultError          error
+}
+
+func (h *helmMock) DeleteRelease(releaseName string, options ...helm.DeleteOption) error {
+	if h.defaultError != nil {
+		return h.defaultError
+	}
+
+	return nil
+}
+
+func (h *helmMock) EnsureTillerInstalled() error {
+	return nil
+}
+
+func (h *helmMock) GetReleaseContent(releaseName string) (*helmclient.ReleaseContent, error) {
+	if h.defaultError != nil {
+		return nil, h.defaultError
+	}
+
+	return h.defaultReleaseContent, nil
+}
+
+func (h *helmMock) GetReleaseHistory(releaseName string) (*helmclient.ReleaseHistory, error) {
+	if h.defaultError != nil {
+		return nil, h.defaultError
+	}
+
+	return h.defaultReleaseHistory, nil
+}
+
+func (h *helmMock) InstallFromTarball(path, ns string, options ...helm.InstallOption) error {
+	return nil
+}
+
+func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
+	return nil
+}

--- a/service/controller/v3/resource/chart/resource.go
+++ b/service/controller/v3/resource/chart/resource.go
@@ -1,0 +1,102 @@
+package chart
+
+import (
+	"reflect"
+
+	"github.com/giantswarm/apprclient"
+	"github.com/giantswarm/helmclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "chartv2"
+)
+
+// Config represents the configuration used to create a new chart resource.
+type Config struct {
+	// Dependencies.
+	ApprClient apprclient.Interface
+	Fs         afero.Fs
+	HelmClient helmclient.Interface
+	K8sClient  kubernetes.Interface
+	Logger     micrologger.Logger
+}
+
+// Resource implements the chart resource.
+type Resource struct {
+	// Dependencies.
+	apprClient apprclient.Interface
+	fs         afero.Fs
+	helmClient helmclient.Interface
+	k8sClient  kubernetes.Interface
+	logger     micrologger.Logger
+}
+
+// New creates a new configured chart resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.ApprClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ApprClient must not be empty", config)
+	}
+	if config.Fs == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Fs must not be empty", config)
+	}
+	if config.HelmClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HelmClient must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		// Dependencies.
+		apprClient: config.ApprClient,
+		fs:         config.Fs,
+		helmClient: config.HelmClient,
+		k8sClient:  config.K8sClient,
+		logger:     config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func isChartModified(a, b ChartState) bool {
+	// ReleaseVersion has changed for the channel so we need to update the Helm
+	// Release.
+	if a.ReleaseVersion != b.ReleaseVersion {
+		return true
+	}
+
+	// ChartValues have changed so we need to update the values for the current
+	// Helm Release.
+	if !reflect.DeepEqual(a.ChartValues, b.ChartValues) {
+		return true
+	}
+
+	return false
+
+}
+
+func toChartState(v interface{}) (ChartState, error) {
+	if v == nil {
+		return ChartState{}, nil
+	}
+
+	chartState, ok := v.(*ChartState)
+	if !ok {
+		return ChartState{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", chartState, v)
+	}
+
+	return *chartState, nil
+}

--- a/service/controller/v3/resource/chart/resource_test.go
+++ b/service/controller/v3/resource/chart/resource_test.go
@@ -1,0 +1,59 @@
+package chart
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_toChartState(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         interface{}
+		expectedState ChartState
+		errorMatcher  func(error) bool
+	}{
+		{
+			name: "case 0: basic match",
+			input: &ChartState{
+				ChartName:      "test-chart",
+				ChannelName:    "test-channel",
+				ReleaseName:    "test-release",
+				ReleaseVersion: "0.1.0",
+			},
+			expectedState: ChartState{
+				ChartName:      "test-chart",
+				ChannelName:    "test-channel",
+				ReleaseName:    "test-release",
+				ReleaseVersion: "0.1.0",
+			},
+		},
+		{
+			name: "case 1: wrong type",
+			input: ChartState{
+				ChartName:      "test-chart",
+				ChannelName:    "test-channel",
+				ReleaseName:    "test-release",
+				ReleaseVersion: "0.1.0",
+			},
+			errorMatcher: IsWrongType,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := toChartState(tc.input)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedState) {
+				t.Fatalf("ChartState == %q, want %q", result, tc.expectedState)
+			}
+		})
+	}
+}

--- a/service/controller/v3/resource/chart/spec.go
+++ b/service/controller/v3/resource/chart/spec.go
@@ -1,0 +1,42 @@
+package chart
+
+// ChartState holds the state of the chart to be reconciled.
+type ChartState struct {
+	// ChartName is the fully qualified name of the Helm Chart.
+	// e.g. quay.io/giantswarm/chart-operator-chart
+	ChartName string
+	// ChartValues are any values that have been set when the Helm Chart was
+	// installed.
+	ChartValues map[string]interface{}
+	// ChannelName is the CNR channel to reconcile against.
+	// e.g. 0.1-beta
+	ChannelName string
+	// ReleaseName is the name of the Helm release when the chart is deployed.
+	// e.g. chart-operator
+	ReleaseName string
+	// ReleaseStatus is the status of the Helm Release.
+	// e.g. DEPLOYED
+	ReleaseStatus string
+	// ReleaseVersion is the version of the Helm Chart to be deployed.
+	// e.g. 0.1.2
+	ReleaseVersion string
+}
+
+// Equals asseses the equality of ChartStates with regards to distinguishing fields.
+func (a *ChartState) Equals(b ChartState) bool {
+	if a.ReleaseName != b.ReleaseName {
+		return false
+	}
+	if a.ReleaseVersion != b.ReleaseVersion {
+		return false
+	}
+	if a.ChartName != b.ChartName {
+		return false
+	}
+	return true
+}
+
+// IsEmpty checks if a ChartState is empty.
+func (c *ChartState) IsEmpty() bool {
+	return c.Equals(ChartState{})
+}

--- a/service/controller/v3/resource/chart/update.go
+++ b/service/controller/v3/resource/chart/update.go
@@ -1,0 +1,106 @@
+package chart
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"k8s.io/helm/pkg/helm"
+
+	"github.com/giantswarm/chart-operator/service/controller/v2/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	chartState, err := toChartState(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if chartState.ReleaseName != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart %s", chartState.ChartName))
+
+		name := key.ChartName(customObject)
+		releaseName := chartState.ReleaseName
+		channel := chartState.ChannelName
+
+		tarballPath, err := r.apprClient.PullChartTarball(name, channel)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		defer func() {
+			err := r.fs.Remove(tarballPath)
+			if err != nil {
+				r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %q failed", tarballPath), "stack", fmt.Sprintf("%#v", err))
+			}
+		}()
+
+		err = r.helmClient.EnsureTillerInstalled()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		values, err := json.Marshal(chartState.ChartValues)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = r.helmClient.UpdateReleaseFromTarball(releaseName, tarballPath,
+			helm.UpdateValueOverrides(values))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart %s", chartState.ChartName))
+
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %s does not need to be updated", chartState.ChartName))
+	}
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentChartState, err := toChartState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredChartState, err := toChartState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the chart has to be updated")
+
+	if currentChartState.ReleaseVersion != "" && isChartModified(currentChartState, desiredChartState) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the chart has to be updated")
+
+		return &desiredChartState, nil
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the chart does not have to be updated")
+	}
+
+	return nil, nil
+}

--- a/service/controller/v3/resource/chart/update_test.go
+++ b/service/controller/v3/resource/chart/update_test.go
@@ -1,0 +1,206 @@
+package chart
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Chart_newUpdateChange(t *testing.T) {
+	customObject := &v1alpha1.ChartConfig{
+		Spec: v1alpha1.ChartConfigSpec{
+			Chart: v1alpha1.ChartConfigSpecChart{
+				Name: "quay.io/giantswarm/chart-operator-chart",
+			},
+		},
+	}
+	tcs := []struct {
+		description         string
+		currentState        *ChartState
+		desiredState        *ChartState
+		expectedUpdateState *ChartState
+	}{
+		{
+			description:  "case 0: empty current state, empty update change",
+			currentState: &ChartState{},
+			desiredState: &ChartState{
+				ReleaseName: "desired-release-name",
+				ChannelName: "desired-channel-name",
+			},
+			expectedUpdateState: nil,
+		},
+		{
+			description: "case 1: nonempty current state, equal desired state, empty update change",
+			currentState: &ChartState{
+				ReleaseName:    "release-name",
+				ChannelName:    "channel-name",
+				ReleaseVersion: "release-version",
+			},
+			desiredState: &ChartState{
+				ReleaseName:    "release-name",
+				ChannelName:    "channel-name",
+				ReleaseVersion: "release-version",
+			},
+			expectedUpdateState: nil,
+		},
+		{
+			description: "case 2: nonempty current state, different release version in desired state, expected desired state",
+			currentState: &ChartState{
+				ReleaseName:    "current-release-name",
+				ChannelName:    "current-channel-name",
+				ReleaseVersion: "current-release-version",
+			},
+			desiredState: &ChartState{
+				ReleaseName:    "desired-release-name",
+				ChannelName:    "desired-channel-name",
+				ReleaseVersion: "desired-release-version",
+			},
+			expectedUpdateState: &ChartState{
+				ChannelName: "desired-channel-name",
+				ReleaseName: "desired-release-name",
+			},
+		},
+		{
+			description: "case 3: nonempty current state, desired state has values, expected desired state",
+			currentState: &ChartState{
+				ReleaseName:    "release-name",
+				ChannelName:    "channel-name",
+				ReleaseVersion: "release-version",
+			},
+			desiredState: &ChartState{
+				ReleaseName: "release-name",
+				ChannelName: "channel-name",
+				ChartValues: map[string]interface{}{
+					"key": "value",
+				},
+				ReleaseVersion: "release-version",
+			},
+			expectedUpdateState: &ChartState{
+				ReleaseName: "release-name",
+				ChannelName: "channel-name",
+				ChartValues: map[string]interface{}{
+					"key": "value",
+				},
+				ReleaseVersion: "release-version",
+			},
+		},
+		{
+			description: "case 4: nonempty current state, desired state has different values, expected desired state",
+			currentState: &ChartState{
+				ReleaseName:    "release-name",
+				ChannelName:    "channel-name",
+				ReleaseVersion: "release-version",
+			},
+			desiredState: &ChartState{
+				ReleaseName: "release-name",
+				ChannelName: "channel-name",
+				ChartValues: map[string]interface{}{
+					"key": "new-value",
+				},
+				ReleaseVersion: "release-version",
+			},
+			expectedUpdateState: &ChartState{
+				ReleaseName: "release-name",
+				ChannelName: "channel-name",
+				ChartValues: map[string]interface{}{
+					"key": "new-value",
+				},
+				ReleaseVersion: "release-version",
+			},
+		},
+		{
+			description: "case 5: current state has values, desired state has equal values, empty update change",
+			currentState: &ChartState{
+				ReleaseName: "release-name",
+				ChannelName: "channel-name",
+				ChartValues: map[string]interface{}{
+					"key": "value",
+				},
+				// ReleaseStatus is set but is not compared.
+				ReleaseStatus:  "DEPLOYED",
+				ReleaseVersion: "release-version",
+			},
+			desiredState: &ChartState{
+				ReleaseName: "release-name",
+				ChannelName: "channel-name",
+				ChartValues: map[string]interface{}{
+					"key": "value",
+				},
+				ReleaseVersion: "release-version",
+			},
+			expectedUpdateState: nil,
+		},
+		{
+			description: "case 6: current state has values, desired state has new release and equal values, expected desired state",
+			currentState: &ChartState{
+				ReleaseName: "release-name",
+				ChannelName: "channel-name",
+				ChartValues: map[string]interface{}{
+					"key": "value",
+				},
+				// ReleaseStatus is set but is not compared.
+				ReleaseStatus:  "DEPLOYED",
+				ReleaseVersion: "release-version",
+			},
+			desiredState: &ChartState{
+				ReleaseName: "release-name",
+				ChannelName: "channel-name",
+				ChartValues: map[string]interface{}{
+					"key": "value",
+				},
+				ReleaseVersion: "new-release-version",
+			},
+			expectedUpdateState: &ChartState{
+				ReleaseName: "release-name",
+				ChannelName: "channel-name",
+				ChartValues: map[string]interface{}{
+					"key": "value",
+				},
+				ReleaseVersion: "new-release-version",
+			},
+		},
+	}
+	var newResource *Resource
+	var err error
+	{
+		c := Config{}
+		c.ApprClient = &apprMock{}
+		c.Fs = afero.NewMemMapFs()
+		c.HelmClient = &helmMock{}
+		c.K8sClient = fake.NewSimpleClientset()
+		c.Logger = microloggertest.New()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newUpdateChange(context.TODO(), customObject, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			if tc.expectedUpdateState == nil && result != nil {
+				t.Fatal("expected", nil, "got", result)
+			}
+			if result != nil {
+				updateChange, ok := result.(*ChartState)
+				if !ok {
+					t.Fatalf("expected '%T', got '%T'", updateChange, result)
+				}
+				if updateChange.ReleaseName != tc.expectedUpdateState.ReleaseName {
+					t.Fatalf("expected ReleaseName %q, got %q", tc.expectedUpdateState.ReleaseName, updateChange.ReleaseName)
+				}
+				if updateChange.ChannelName != tc.expectedUpdateState.ChannelName {
+					t.Fatalf("expected ChannelName %q, got %q", tc.expectedUpdateState.ChannelName, updateChange.ChannelName)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v3/resource_set.go
+++ b/service/controller/v3/resource_set.go
@@ -1,0 +1,154 @@
+package v2
+
+import (
+	"context"
+
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/apprclient"
+	"github.com/giantswarm/helmclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/chart-operator/service/controller/v2/key"
+	"github.com/giantswarm/chart-operator/service/controller/v2/resource/chart"
+)
+
+const (
+	// ResourceRetries presents number of retries for failed Resource
+	// operation before giving up.
+	ResourceRetries uint64 = 3
+)
+
+// ResourceSetConfig contains necessary dependencies and settings for
+// ChartConfig controller ResourceSet configuration.
+type ResourceSetConfig struct {
+	// Dependencies.
+	ApprClient apprclient.Interface
+	Fs         afero.Fs
+	HelmClient helmclient.Interface
+	K8sClient  kubernetes.Interface
+	Logger     micrologger.Logger
+
+	// Settings.
+	HandledVersionBundles []string
+	ProjectName           string
+}
+
+// NewResourceSet returns a configured ChartConfig controller ResourceSet.
+func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	// Settings.
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	var chartResource controller.Resource
+	{
+		c := chart.Config{
+			ApprClient: config.ApprClient,
+			Fs:         config.Fs,
+			HelmClient: config.HelmClient,
+			K8sClient:  config.K8sClient,
+			Logger:     config.Logger,
+		}
+
+		ops, err := chart.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		chartResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		chartResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			BackOffFactory: func() backoff.BackOff { return backoff.WithMaxTries(backoff.NewExponentialBackOff(), ResourceRetries) },
+			Logger:         config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		return ctx, nil
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		chartConfig, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(chartConfig) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}
+
+func toCRUDResource(logger micrologger.Logger, ops controller.CRUDResourceOps) (*controller.CRUDResource, error) {
+	c := controller.CRUDResourceConfig{
+		Logger: logger,
+		Ops:    ops,
+	}
+
+	r, err := controller.NewCRUDResource(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}

--- a/service/controller/v3/version_bundle.go
+++ b/service/controller/v3/version_bundle.go
@@ -1,0 +1,20 @@
+package v2
+
+import (
+	"github.com/giantswarm/versionbundle"
+)
+
+func VersionBundle() versionbundle.Bundle {
+	return versionbundle.Bundle{
+		Changelogs: []versionbundle.Changelog{
+			{
+				Component:   "chart-operator",
+				Description: "Add your changes here.",
+				Kind:        versionbundle.KindAdded,
+			},
+		},
+		Components: []versionbundle.Component{},
+		Name:       "chart-operator",
+		Version:    "0.2.0",
+	}
+}


### PR DESCRIPTION
This PR got created by `opsctl` in order to automate the creation of a new WIP version bundle. This specific PR is to copy the latest resource package only. FYI @giantswarm/sig-operator @giantswarm/sig-customer @giantswarm/sre.