### PR TITLE
Push chart to quay with sha version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,10 +74,9 @@ jobs:
     - run:
         name: publish to beta
         command: ./architect publish
-
-    - run: sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/chart-operator-chart/Chart.yaml
-
-    - run: ./architect deploy
+    - run: |
+        sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/chart-operator-chart/Chart.yaml
+        ./architect deploy
 
   publish_to_stable:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,9 @@ jobs:
     - run:
         name: publish to beta
         command: ./architect publish
-        
+
     - run: sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/chart-operator-chart/Chart.yaml
+
     - run: ./architect deploy
 
   publish_to_stable:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,9 @@ jobs:
     - run:
         name: publish to beta
         command: ./architect publish
-
-    - run: sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/chart-operator-chart/Chart.yaml && ./architect deploy
+        
+    - run: sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/chart-operator-chart/Chart.yaml
+    - run: ./architect deploy
 
   publish_to_stable:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
         ./architect version
     - run: ./architect build
     - run: ./architect publish --pipeline=false --channels=${CIRCLE_SHA1}
+    - run: |
+        sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/chart-operator-chart/Chart.yaml
+        ./architect publish --pipeline=false --channels=${CIRCLE_SHA1}
     - persist_to_workspace:
         root: .
         paths:
@@ -76,7 +79,7 @@ jobs:
         command: ./architect publish
     - run: |
         sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/chart-operator-chart/Chart.yaml
-        ./architect deploy
+        ./architect publish
 
   publish_to_stable:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,8 @@ jobs:
         name: publish to beta
         command: ./architect publish
 
+    - run: sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/chart-operator-chart/Chart.yaml && ./architect deploy
+
   publish_to_stable:
     machine: true
     steps:


### PR DESCRIPTION
I talked about this with @rossf7 and @JosephSalisbury to try and get `chart-operator` deployed through `draughtsman`.

The idea here is to replace the version which is used for `chart-operator` on guest clusters  with the usual `1.0.0-SHA` version which is required for draughtsman.

towards https://github.com/giantswarm/giantswarm/issues/3907