### PR TITLE
Add missing version endpoint

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -66,6 +66,7 @@ func New(config Config) (microserver.Server, error) {
 			Viper:       config.Viper,
 			Endpoints: []microserver.Endpoint{
 				endpointCollection.Healthz,
+				endpointCollection.Version,
 			},
 			ErrorEncoder: errorEncoder,
 		},


### PR DESCRIPTION
Endpoint needs to be wired so cluster-operator can scrape it.