### PR TITLE
Align rbac rules with other operators

### DIFF
--- a/helm/chart-operator-chart/templates/rbac.yaml
+++ b/helm/chart-operator-chart/templates/rbac.yaml
@@ -16,9 +16,20 @@ rules:
   - core.giantswarm.io
   resources:
   - chartconfigs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - core.giantswarm.io
+  resources:
   - chartconfigs/status
   verbs:
-  - "*"
+  - create
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
We gave too many rights to the status resource foo. 
This is now aligned to e.g. aws-operator https://github.com/giantswarm/aws-operator/blob/master/helm/aws-operator-chart/templates/01-rbac.yaml#L26-L41