### PR TITLE
Remove priority class

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.3.0
+version: 0.3.1

--- a/helm/chart-operator-chart/templates/deployment.yaml
+++ b/helm/chart-operator-chart/templates/deployment.yaml
@@ -27,7 +27,6 @@ spec:
           - key: config.yaml
             path: config.yaml
       serviceAccountName: {{ .Values.name }}
-      priorityClassName: system-cluster-critical
       containers:
       - name: {{ .Values.name }}
         image: "quay.io/{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
I added the priority class but its not working correctly in the `giantswarm` namespace.

```
Warning  FailedCreate  7m (x18 over 18m)  replicaset-controller  Error creating: pods "chart-operator-7c6db97676-" is forbidden: pods with system-cluster-critical priorityClass is not permitted in giantswarm namespace
```

Removing to fix alerts. I'll reintroduce once tested in the `giantswarm` namespace.

https://gigantic.slack.com/archives/C03CPNRTS/p1537860674000100
