### PR TITLE
v4: changelog and version

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.3.2
+version: 0.4.0

--- a/service/controller/v4/version_bundle.go
+++ b/service/controller/v4/version_bundle.go
@@ -9,7 +9,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "chart-operator",
-				Description: "Add your changes here.",
+				Description: "Added support for user configmaps.",
 				Kind:        versionbundle.KindAdded,
 			},
 		},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4185

We should also freeze `v4` of chart-operator when `v7` of cluster-operator is released. This release will have the per cluster config changes.

This gets the changelog and version sorted.