### PR TITLE
uses architect rendering for chart yaml version

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.3.2
+version: [[ .Version ]]-[[ .SHA ]]


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3313. Just a preparation PR. Must not be merged just yet. We have to sort `architect` first. 