### PR TITLE
set tiller namespace to kube-system

### DIFF
--- a/helm/chart-operator-chart/templates/configmap.yaml
+++ b/helm/chart-operator-chart/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
       cnr:
         address: '{{ .Values.cnr.address }}'
       helm:
-        tillerNamespace:  '{{ .Values.namespace }}'
+        tillerNamespace:  '{{ .Values.tillerNamespace }}'
       kubernetes:
         incluster: true
         watch:

--- a/helm/chart-operator-chart/values.yaml
+++ b/helm/chart-operator-chart/values.yaml
@@ -4,6 +4,7 @@
 
 name: chart-operator
 namespace: giantswarm
+tillerNamespace: kube-system
 port: 8000
 
 replicas: 1

--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -6,4 +6,5 @@ package templates
 const ChartOperatorValues = `cnr:
   address: http://cnr-server:5000
 clusterDNSIP: 10.96.0.10
+tillerNamespace: giantswarm
 `


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/4537

Point chart-operator to tiller in `kube-system` namespace on control planes.

