### PR TITLE
Revert "set tiller namespace to kube-system (#151)"

### DIFF
--- a/helm/chart-operator-chart/templates/configmap.yaml
+++ b/helm/chart-operator-chart/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
       cnr:
         address: '{{ .Values.cnr.address }}'
       helm:
-        tillerNamespace:  '{{ .Values.tillerNamespace }}'
+        tillerNamespace:  '{{ .Values.namespace }}'
       kubernetes:
         incluster: true
         watch:

--- a/helm/chart-operator-chart/values.yaml
+++ b/helm/chart-operator-chart/values.yaml
@@ -4,7 +4,6 @@
 
 name: chart-operator
 namespace: giantswarm
-tillerNamespace: kube-system
 port: 8000
 
 replicas: 1

--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -6,5 +6,4 @@ package templates
 const ChartOperatorValues = `cnr:
   address: http://cnr-server:5000
 clusterDNSIP: 10.96.0.10
-tillerNamespace: giantswarm
 `


### PR DESCRIPTION
This reverts commit ffd22909f61e9e20c6dfde3eafdd2b3ef69bfe21.

Didn't measured the impact of this.

Release running cluster-operator version prior to `0.8.0` will fail, since the namespace is not defined to `giantswarm` their.