### PR TITLE
Skip pinging tiller when there is no ChartConfig

### DIFF
--- a/service/collector/tiller_reachable.go
+++ b/service/collector/tiller_reachable.go
@@ -29,7 +29,8 @@ func (c *Collector) collectTillerReachable(ctx context.Context, ch chan<- promet
 	if err == nil && len(chartConfigs) == 0 {
 		// Skip pinging tiller when there is no ChartConfig,
 		// as tiller is only installed when there is at least one ChartConfig to reconcile.
-		c.logger.Log("level", "error", "message", "skip pinging Tiller")
+		c.logger.Log("level", "error", "message", "did not collect Tiller reachability")
+		c.logger.Log("level", "error", "message", "no ChartConfg CRs in the cluster")
 
 		value = 1
 	} else {

--- a/service/collector/tiller_reachable.go
+++ b/service/collector/tiller_reachable.go
@@ -26,7 +26,7 @@ func (c *Collector) collectTillerReachable(ctx context.Context, ch chan<- promet
 	if err != nil {
 		c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("could not get ChartConfigs"), "stack", fmt.Sprintf("%#v", err))
 	}
-	if err == nil && len(chartConfigs) <= 0 {
+	if err == nil && len(chartConfigs) == 0 {
 		// Skip pinging tiller when there is no ChartConfig,
 		// as tiller is only installed when there is at least one ChartConfig to reconcile.
 		c.logger.Log("level", "error", "message", "skip pinging Tiller")

--- a/service/collector/tiller_reachable.go
+++ b/service/collector/tiller_reachable.go
@@ -25,8 +25,10 @@ func (c *Collector) collectTillerReachable(ctx context.Context, ch chan<- promet
 	chartConfigs, err := c.getChartConfigs()
 	if err != nil {
 		c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("could not get ChartConfigs"), "stack", fmt.Sprintf("%#v", err))
+		return
 	}
-	if err == nil && len(chartConfigs) == 0 {
+
+	if len(chartConfigs) == 0 {
 		// Skip pinging tiller when there is no ChartConfig,
 		// as tiller is only installed when there is at least one ChartConfig to reconcile.
 		c.logger.Log("level", "error", "message", "did not collect Tiller reachability")

--- a/service/collector/tiller_reachable.go
+++ b/service/collector/tiller_reachable.go
@@ -36,7 +36,7 @@ func (c *Collector) collectTillerReachable(ctx context.Context, ch chan<- promet
 	} else {
 		err := c.helmClient.PingTiller(ctx)
 		if err != nil {
-			c.logger.Log("level", "error", "message", "could not ping Tiller", "stack", fmt.Sprintf("%#v", err))
+			c.logger.Log("level", "error", "message", "failed to collect Tiller reachability", "stack", fmt.Sprintf("%#v", err))
 
 			value = 0
 		} else {

--- a/service/collector/tiller_reachable.go
+++ b/service/collector/tiller_reachable.go
@@ -19,16 +19,28 @@ var (
 )
 
 func (c *Collector) collectTillerReachable(ctx context.Context, ch chan<- prometheus.Metric) {
-	c.logger.LogCtx(ctx, "level", "debug", "message", "collecting Tiller reachability")
-
-	err := c.helmClient.PingTiller(ctx)
 	var value float64
-	if err != nil {
-		c.logger.Log("level", "error", "message", "could not ping Tiller", "stack", fmt.Sprintf("%#v", err))
 
-		value = 0
-	} else {
+	c.logger.LogCtx(ctx, "level", "debug", "message", "collecting Tiller reachability")
+	chartConfigs, err := c.getChartConfigs()
+	if err != nil {
+		c.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("could not get ChartConfigs"), "stack", fmt.Sprintf("%#v", err))
+	}
+	if err == nil && len(chartConfigs) <= 0 {
+		// Skip pinging tiller when there is no ChartConfig,
+		// as tiller is only installed when there is at least one ChartConfig to reconcile.
+		c.logger.Log("level", "error", "message", "skip pinging Tiller")
+
 		value = 1
+	} else {
+		err := c.helmClient.PingTiller(ctx)
+		if err != nil {
+			c.logger.Log("level", "error", "message", "could not ping Tiller", "stack", fmt.Sprintf("%#v", err))
+
+			value = 0
+		} else {
+			value = 1
+		}
 	}
 
 	ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/4537#issuecomment-442811487

Skip pinging tiller when there is no ChartConfig as it is only installed whenever there is a ChartConfig to reconcile.
