### PR TITLE
Add EnsureTillerInstalled to status resource

### DIFF
--- a/service/controller/chart/v1/resource/status/create.go
+++ b/service/controller/chart/v1/resource/status/create.go
@@ -21,6 +21,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	releaseName := key.ReleaseName(cr)
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("getting status for release %#q", releaseName))
 
+	err = r.helmClient.EnsureTillerInstalled(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseName)
 	if helmclient.IsReleaseNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q not found", releaseName))


### PR DESCRIPTION
I hit errors running chart-operator against a fresh cluster with no tiller installed. Adds a call to the status resource for `EnsureTillerInstalled` to fix this.