### PR TITLE
Set priority class for chart-operator pod

### DIFF
--- a/helm/chart-operator-chart/templates/deployment.yaml
+++ b/helm/chart-operator-chart/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+      priorityClassName: system-cluster-critical
       serviceAccountName: {{ .Values.name }}
       dnsPolicy: None
       dnsConfig:


### PR DESCRIPTION
The priority class was missing for chart-operator. This causes problems with cluster-autoscaler as the chart-operator pod can be evicted and we lose part of our control plane.

