### PR TITLE
Revert "Set priority class for chart-operator pod (#195)"

### DIFF
--- a/helm/chart-operator-chart/templates/deployment.yaml
+++ b/helm/chart-operator-chart/templates/deployment.yaml
@@ -29,7 +29,6 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-      priorityClassName: system-cluster-critical
       serviceAccountName: {{ .Values.name }}
       dnsPolicy: None
       dnsConfig:


### PR DESCRIPTION
Removes the priority class. chart-operator runs in control planes but is unused. The priority classes are missing so this broke and triggered alerts.

The issue I was trying to fix is a problem reported by @pipo02mix with tenant clusters. Due to cluster-autoscaler the chart-operator pod can be evicted as it misses the priority class.

But we don't need a fix until cluster-autoscaler ships. I'll reintroduce once we have a fix that works for tenants and control planes.