### PR TITLE
Default tiller namespace to kube-system

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.3.2
+version: 0.4.0

--- a/helm/chart-operator-chart/templates/configmap.yaml
+++ b/helm/chart-operator-chart/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
       cnr:
         address: '{{ .Values.cnr.address }}'
       helm:
-        tillerNamespace:  '{{ .Values.namespace }}'
+        tillerNamespace:  '{{ .Values.tiller.namespace }}'
       kubernetes:
         incluster: true
         watch:

--- a/helm/chart-operator-chart/values.yaml
+++ b/helm/chart-operator-chart/values.yaml
@@ -10,6 +10,9 @@ replicas: 1
 
 clusterDNSIP: 172.31.0.10
 
+cnr:
+  address: https://quay.io
+
 image:
   registry: quay.io
   repository: giantswarm/chart-operator
@@ -23,5 +26,5 @@ resources:
     cpu: 250m
     memory: 250Mi
 
-cnr:
-  address: https://quay.io
+tiller:
+  namespace: kube-system

--- a/integration/setup/config.go
+++ b/integration/setup/config.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	namespace       = "giantswarm"
-	tillerNamespace = "giantswarm"
+	tillerNamespace = "kube-system"
 )
 
 type Config struct {


### PR DESCRIPTION
Fix for a bug found during integration testing yesterday. In the control plane we should use the existing tiller in kube-system and not create another tiller in giantswarm.

We only use tiller in giantswarm for tenant clusters to avoid conflicting with customers.

See https://github.com/giantswarm/cluster-operator/pull/398/files for the related change.