### PR TITLE
Add RBAC rules for updating CRD status subresource

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.4.0
+version: 0.4.1

--- a/helm/chart-operator-chart/templates/rbac.yaml
+++ b/helm/chart-operator-chart/templates/rbac.yaml
@@ -12,6 +12,14 @@ rules:
   - customresourcedefinitions
   verbs:
   - "*"
+  - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions/status
+  verbs:
+  - create
+  - patch
+  - update
 - apiGroups:
   - application.giantswarm.io
   resources:

--- a/helm/chart-operator-chart/templates/rbac.yaml
+++ b/helm/chart-operator-chart/templates/rbac.yaml
@@ -12,7 +12,7 @@ rules:
   - customresourcedefinitions
   verbs:
   - "*"
-  - apiGroups:
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions/status


### PR DESCRIPTION
See https://gigantic.slack.com/archives/C03CPNRTS/p1552400523030300.

We had a problem in centaur with chart-operator failing to start due to this error. 

```
W 03/12 15:44:31 retrying backoff in '1s' due to error | backoff/notifier.go:13 | controller=chart-operator-chartconfig
    /go/src/github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:143:
    /go/src/github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:381:
    /go/src/github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/operatorkit/client/k8scrdclient/k8scrdclient.go:85:
    /go/src/github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/operatorkit/client/k8scrdclient/k8scrdclient.go:140:
    /go/src/github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/operatorkit/client/k8scrdclient/k8scrdclient.go:131:
    customresourcedefinitions.apiextensions.k8s.io "chartconfigs.core.giantswarm.io" is forbidden: User "system:serviceaccount:giantswarm:chart-operator" cannot update resource "customresourcedefinitions/status" in API group "apiextensions.k8s.io" at the cluster scope
```

Unclear why this has started happening but this allowed the operator to start successfully.