### PR TITLE
Bump version to link upgrades to cluster-operator version

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.4.1
+version: 0.5.0


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5624

See https://github.com/giantswarm/giantswarm/issues/5624#issuecomment-479584707.