### PR TITLE
Bump chart-operator helm chart to 0.6.0

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.5.0
+version: 0.6.0


### PR DESCRIPTION
We had some problems with the wrong commits getting pushed to the appr release channel. This is mitigated by using the 0-6-stable channel only in the WIP release.

See https://github.com/giantswarm/cluster-operator/pull/438