### PR TITLE
 Enable force upgrade configured by annotation in both controllers

### DIFF
--- a/service/controller/chart/v1/key/key.go
+++ b/service/controller/chart/v1/key/key.go
@@ -1,11 +1,17 @@
 package key
 
 import (
+	"strconv"
+
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
 )
 
 const (
+	// ForceHelmUpgradeAnnotationName is the name of the annotation that
+	// controls whether force is used when upgrading the Helm release.
+	ForceHelmUpgradeAnnotationName = "chart-operator.giantswarm.io/force-helm-upgrade"
+
 	// ValuesMD5ChecksumAnnotationName is the name of the annotation storing
 	// an MD5 checksum of the Helm release values.
 	ValuesMD5ChecksumAnnotationName = "chart-operator.giantswarm.io/values-md5-checksum"
@@ -23,6 +29,20 @@ func ConfigMapName(customResource v1alpha1.Chart) string {
 
 func ConfigMapNamespace(customResource v1alpha1.Chart) string {
 	return customResource.Spec.Config.ConfigMap.Namespace
+}
+
+func HasForceUpgradeAnnotation(customResource v1alpha1.Chart) (bool, error) {
+	val, ok := customResource.Annotations[ForceHelmUpgradeAnnotationName]
+	if !ok {
+		return false, nil
+	}
+
+	result, err := strconv.ParseBool(val)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return result, nil
 }
 
 func IsDeleted(customResource v1alpha1.Chart) bool {

--- a/service/controller/chart/v1/key/key.go
+++ b/service/controller/chart/v1/key/key.go
@@ -31,18 +31,20 @@ func ConfigMapNamespace(customResource v1alpha1.Chart) string {
 	return customResource.Spec.Config.ConfigMap.Namespace
 }
 
-func HasForceUpgradeAnnotation(customResource v1alpha1.Chart) (bool, error) {
+func HasForceUpgradeAnnotation(customResource v1alpha1.Chart) bool {
 	val, ok := customResource.Annotations[ForceHelmUpgradeAnnotationName]
 	if !ok {
-		return false, nil
+		return false
 	}
 
 	result, err := strconv.ParseBool(val)
 	if err != nil {
-		return false, microerror.Mask(err)
+		// If we cannot parse the boolean we return false and this is shown
+		// in the logs.
+		return false
 	}
 
-	return result, nil
+	return result
 }
 
 func IsDeleted(customResource v1alpha1.Chart) bool {

--- a/service/controller/chart/v1/key/key_test.go
+++ b/service/controller/chart/v1/key/key_test.go
@@ -51,7 +51,6 @@ func Test_HasForceUpgradeAnnotation(t *testing.T) {
 		name           string
 		input          v1alpha1.Chart
 		expectedResult bool
-		hasError       bool
 	}{
 		{
 			name: "case 0: no annotations",
@@ -103,19 +102,12 @@ func Test_HasForceUpgradeAnnotation(t *testing.T) {
 				},
 			},
 			expectedResult: false,
-			hasError:       true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := HasForceUpgradeAnnotation(tc.input)
-			switch {
-			case err != nil && tc.hasError == false:
-				t.Fatalf("error == %#v, want nil", err)
-			case err == nil && tc.hasError == true:
-				t.Fatalf("error == nil, want non-nil")
-			}
+			result := HasForceUpgradeAnnotation(tc.input)
 
 			if result != tc.expectedResult {
 				t.Fatalf("HasForceUpgradeAnnotation == %t, want %t", result, tc.expectedResult)

--- a/service/controller/chart/v1/resource/release/update.go
+++ b/service/controller/chart/v1/resource/release/update.go
@@ -37,15 +37,16 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			}
 		}()
 
-		// TODO: Remove once upgrade --force support for re-installing releases
-		// is supported.
-		//
-		//	See https://github.com/giantswarm/giantswarm/issues/5612
-		//
+		upgradeForce, err := key.HasForceUpgradeAnnotation(cr)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 
 		// We need to pass the ValueOverrides option to make the update process
 		// use the default values and prevent errors on nested values.
-		err = r.helmClient.UpdateReleaseFromTarball(ctx, releaseState.Name, tarballPath, helm.UpdateValueOverrides(releaseState.ValuesYAML))
+		err = r.helmClient.UpdateReleaseFromTarball(ctx, releaseState.Name, tarballPath,
+			helm.UpdateValueOverrides(releaseState.ValuesYAML),
+			helm.UpgradeForce(upgradeForce))
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/chart/v1/resource/release/update.go
+++ b/service/controller/chart/v1/resource/release/update.go
@@ -21,8 +21,10 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		return microerror.Mask(err)
 	}
 
+	upgradeForce := key.HasForceUpgradeAnnotation(cr)
+
 	if releaseState.Name != "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release %#q", releaseState.Name))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release %#q with force == %t", releaseState.Name, upgradeForce))
 
 		tarballURL := key.TarballURL(cr)
 		tarballPath, err := r.helmClient.PullChartTarball(ctx, tarballURL)
@@ -36,11 +38,6 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %#q failed", tarballPath), "stack", fmt.Sprintf("%#v", err))
 			}
 		}()
-
-		upgradeForce, err := key.HasForceUpgradeAnnotation(cr)
-		if err != nil {
-			return microerror.Mask(err)
-		}
 
 		// We need to pass the ValueOverrides option to make the update process
 		// use the default values and prevent errors on nested values.

--- a/service/controller/chartconfig/v6/key/key.go
+++ b/service/controller/chartconfig/v6/key/key.go
@@ -1,6 +1,8 @@
 package key
 
 import (
+	"strconv"
+
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 )
@@ -19,6 +21,20 @@ func ConfigMapName(customObject v1alpha1.ChartConfig) string {
 
 func ConfigMapNamespace(customObject v1alpha1.ChartConfig) string {
 	return customObject.Spec.Chart.ConfigMap.Namespace
+}
+
+func HasForceUpgradeAnnotation(customObject v1alpha1.ChartConfig) (bool, error) {
+	val, ok := customObject.Annotations["chart-operator.giantswarm.io/force-helm-upgrade"]
+	if !ok {
+		return false, nil
+	}
+
+	result, err := strconv.ParseBool(val)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return result, nil
 }
 
 func Namespace(customObject v1alpha1.ChartConfig) string {

--- a/service/controller/chartconfig/v6/resource/chart/update.go
+++ b/service/controller/chartconfig/v6/resource/chart/update.go
@@ -46,7 +46,14 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			return microerror.Mask(err)
 		}
 
-		err = r.helmClient.UpdateReleaseFromTarball(ctx, releaseName, tarballPath, helm.UpdateValueOverrides(values))
+		upgradeForce, err := key.HasForceUpgradeAnnotation(customObject)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = r.helmClient.UpdateReleaseFromTarball(ctx, releaseName, tarballPath,
+			helm.UpdateValueOverrides(values),
+			helm.UpgradeForce(upgradeForce))
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5745 and https://github.com/giantswarm/giantswarm/issues/5612

Adds a new `chart-operator.giantswarm.io/force-helm-upgrade` annotation to both chart and chartconfig CRs that triggers a "helm upgrade --force".