### PR TITLE
tighten PSP security

### DIFF
--- a/helm/chart-operator-chart/templates/psp.yaml
+++ b/helm/chart-operator-chart/templates/psp.yaml
@@ -12,12 +12,12 @@ spec:
     rule: MustRunAs
     ranges:
       - min: 1
-      - max: 65535
+        max: 65535
   fsGroup:
     rule: MustRunAs
     ranges:
       - min: 1
-      - max: 65535
+        max: 65535
   seLinux:
     rule: RunAsAny
   supplementalGroups:

--- a/helm/chart-operator-chart/templates/psp.yaml
+++ b/helm/chart-operator-chart/templates/psp.yaml
@@ -8,14 +8,26 @@ metadata:
 spec:
   runAsUser:
     rule: MustRunAsNonRoot
+  runAsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+      - max: 65535
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+      - min: 1
+      - max: 65535
   seLinux:
     rule: RunAsAny
   supplementalGroups:
     rule: RunAsAny
   volumes:
-  - '*'
+    - 'configMap'
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
towards giantswarm/giantswarm/issues/6013

chart-operator already runs as non root, so this PR just improves the existing PSP.