### PR TITLE
Cancelling chartconfig/chart resource when chart had been cordon

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -5,9 +5,9 @@ package annotation
 const (
 	// CordonReasonAnnotationName is the name of the annotation that indicates
 	// the reason of why chart-operator should not apply any update on this chart CR.
-	CordonReasonAnnotationName = "app-operator.giantswarm.io/cordon-reason"
+	CordonReasonAnnotationName = "chart-operator.giantswarm.io/cordon-reason"
 
 	// CordonUntilAnnotationName is the name of the annotation that indicates
 	// the expiration date of rule of this cordon.
-	CordonUntilAnnotationName = "app-operator.giantswarm.io/cordon-until"
+	CordonUntilAnnotationName = "chart-operator.giantswarm.io/cordon-until"
 )

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -3,11 +3,11 @@
 package annotation
 
 const (
-	// CordonReasonAnnotationName is the name of the annotation that indicates
+	// CordonReason is the name of the annotation that indicates
 	// the reason of why chart-operator should not apply any update on this chart CR.
-	CordonReasonAnnotationName = "chart-operator.giantswarm.io/cordon-reason"
+	CordonReason = "chart-operator.giantswarm.io/cordon-reason"
 
-	// CordonUntilAnnotationName is the name of the annotation that indicates
+	// CordonExpirationDate is the name of the annotation that indicates
 	// the expiration date of rule of this cordon.
-	CordonUntilAnnotationName = "chart-operator.giantswarm.io/cordon-until"
+	CordonExpirationDate = "chart-operator.giantswarm.io/cordon-until"
 )

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -1,0 +1,13 @@
+// Package annotation contains common Kubernetes metadata. These are defined in
+// https://github.com/giantswarm/fmt/blob/master/kubernetes/annotations_and_labels.md.
+package annotation
+
+const (
+	// CordonReasonAnnotationName is the name of the annotation that indicates
+	// the reason of why chart-operator should not apply any update on this chart CR.
+	CordonReasonAnnotationName = "app-operator.giantswarm.io/cordon-reason"
+
+	// CordonUntilAnnotationName is the name of the annotation that indicates
+	// the expiration date of rule of this cordon.
+	CordonUntilAnnotationName = "app-operator.giantswarm.io/cordon-until"
+)

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -7,7 +7,7 @@ const (
 	// the reason of why chart-operator should not apply any update on this chart CR.
 	CordonReason = "chart-operator.giantswarm.io/cordon-reason"
 
-	// CordonExpirationDate is the name of the annotation that indicates
+	// CordonUntilDate is the name of the annotation that indicates
 	// the expiration date of rule of this cordon.
-	CordonExpirationDate = "chart-operator.giantswarm.io/cordon-until"
+	CordonUntilDate = "chart-operator.giantswarm.io/cordon-until"
 )

--- a/service/controller/chartconfig/v7/key/key.go
+++ b/service/controller/chartconfig/v7/key/key.go
@@ -30,7 +30,7 @@ func CordonReason(customObject v1alpha1.ChartConfig) string {
 }
 
 func CordonUntil(customObject v1alpha1.ChartConfig) string {
-	return customObject.GetAnnotations()[annotation.CordonExpirationDate]
+	return customObject.GetAnnotations()[annotation.CordonUntilDate]
 }
 
 func HasForceUpgradeAnnotation(customObject v1alpha1.ChartConfig) (bool, error) {
@@ -49,7 +49,7 @@ func HasForceUpgradeAnnotation(customObject v1alpha1.ChartConfig) (bool, error) 
 
 func IsCordoned(customObject v1alpha1.ChartConfig) bool {
 	_, reasonOk := customObject.Annotations[annotation.CordonReason]
-	_, untilOk := customObject.Annotations[annotation.CordonExpirationDate]
+	_, untilOk := customObject.Annotations[annotation.CordonUntilDate]
 
 	if reasonOk && untilOk {
 		return true

--- a/service/controller/chartconfig/v7/key/key.go
+++ b/service/controller/chartconfig/v7/key/key.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/chart-operator/pkg/annotation"
 )
 
 func ChartName(customObject v1alpha1.ChartConfig) string {
@@ -23,6 +25,22 @@ func ConfigMapNamespace(customObject v1alpha1.ChartConfig) string {
 	return customObject.Spec.Chart.ConfigMap.Namespace
 }
 
+func CordonReason(customObject v1alpha1.ChartConfig) string {
+	val, ok := customObject.Annotations[annotation.CordonReasonAnnotationName]
+	if ok {
+		return val
+	}
+	return ""
+}
+
+func CordonUntil(customObject v1alpha1.ChartConfig) string {
+	val, ok := customObject.Annotations[annotation.CordonUntilAnnotationName]
+	if ok {
+		return val
+	}
+	return ""
+}
+
 func HasForceUpgradeAnnotation(customObject v1alpha1.ChartConfig) (bool, error) {
 	val, ok := customObject.Annotations["chart-operator.giantswarm.io/force-helm-upgrade"]
 	if !ok {
@@ -35,6 +53,18 @@ func HasForceUpgradeAnnotation(customObject v1alpha1.ChartConfig) (bool, error) 
 	}
 
 	return result, nil
+}
+
+func IsCordoned(customObject v1alpha1.ChartConfig) bool {
+	_, reasonOk := customObject.Annotations[annotation.CordonReasonAnnotationName]
+	_, untilOk := customObject.Annotations[annotation.CordonUntilAnnotationName]
+
+	if reasonOk && untilOk {
+		return true
+	} else {
+		return false
+	}
+
 }
 
 func Namespace(customObject v1alpha1.ChartConfig) string {

--- a/service/controller/chartconfig/v7/key/key.go
+++ b/service/controller/chartconfig/v7/key/key.go
@@ -26,19 +26,11 @@ func ConfigMapNamespace(customObject v1alpha1.ChartConfig) string {
 }
 
 func CordonReason(customObject v1alpha1.ChartConfig) string {
-	val, ok := customObject.Annotations[annotation.CordonReasonAnnotationName]
-	if ok {
-		return val
-	}
-	return ""
+	return customObject.GetAnnotations()[annotation.CordonReasonAnnotationName]
 }
 
 func CordonUntil(customObject v1alpha1.ChartConfig) string {
-	val, ok := customObject.Annotations[annotation.CordonUntilAnnotationName]
-	if ok {
-		return val
-	}
-	return ""
+	return customObject.GetAnnotations()[annotation.CordonUntilAnnotationName]
 }
 
 func HasForceUpgradeAnnotation(customObject v1alpha1.ChartConfig) (bool, error) {

--- a/service/controller/chartconfig/v7/key/key.go
+++ b/service/controller/chartconfig/v7/key/key.go
@@ -26,11 +26,11 @@ func ConfigMapNamespace(customObject v1alpha1.ChartConfig) string {
 }
 
 func CordonReason(customObject v1alpha1.ChartConfig) string {
-	return customObject.GetAnnotations()[annotation.CordonReasonAnnotationName]
+	return customObject.GetAnnotations()[annotation.CordonReason]
 }
 
 func CordonUntil(customObject v1alpha1.ChartConfig) string {
-	return customObject.GetAnnotations()[annotation.CordonUntilAnnotationName]
+	return customObject.GetAnnotations()[annotation.CordonExpirationDate]
 }
 
 func HasForceUpgradeAnnotation(customObject v1alpha1.ChartConfig) (bool, error) {
@@ -48,8 +48,8 @@ func HasForceUpgradeAnnotation(customObject v1alpha1.ChartConfig) (bool, error) 
 }
 
 func IsCordoned(customObject v1alpha1.ChartConfig) bool {
-	_, reasonOk := customObject.Annotations[annotation.CordonReasonAnnotationName]
-	_, untilOk := customObject.Annotations[annotation.CordonUntilAnnotationName]
+	_, reasonOk := customObject.Annotations[annotation.CordonReason]
+	_, untilOk := customObject.Annotations[annotation.CordonExpirationDate]
 
 	if reasonOk && untilOk {
 		return true

--- a/service/controller/chartconfig/v7/key/key.go
+++ b/service/controller/chartconfig/v7/key/key.go
@@ -7,16 +7,6 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-const (
-	// CordonReasonAnnotationName is the name of the annotation that indicates
-	// the reason of why chart-operator should not apply any update on this chart CR.
-	CordonReasonAnnotationName = "app-operator.giantswarm.io/cordon-reason"
-
-	// CordonUntilAnnotationName is the name of the annotation that indicates
-	// the expiration date of rule of this cordon.
-	CordonUntilAnnotationName = "app-operator.giantswarm.io/cordon-until"
-)
-
 func ChartName(customObject v1alpha1.ChartConfig) string {
 	return customObject.Spec.Chart.Name
 }

--- a/service/controller/chartconfig/v7/key/key.go
+++ b/service/controller/chartconfig/v7/key/key.go
@@ -7,6 +7,16 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+const (
+	// CordonReasonAnnotationName is the name of the annotation that indicates
+	// the reason of why chart-operator should not apply any update on this chart CR.
+	CordonReasonAnnotationName = "app-operator.giantswarm.io/cordon-reason"
+
+	// CordonUntilAnnotationName is the name of the annotation that indicates
+	// the expiration date of rule of this cordon.
+	CordonUntilAnnotationName = "app-operator.giantswarm.io/cordon-until"
+)
+
 func ChartName(customObject v1alpha1.ChartConfig) string {
 	return customObject.Spec.Chart.Name
 }

--- a/service/controller/chartconfig/v7/key/key_test.go
+++ b/service/controller/chartconfig/v7/key/key_test.go
@@ -112,7 +112,7 @@ func Test_CordonUntil(t *testing.T) {
 	obj := v1alpha1.ChartConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				annotation.CordonExpirationDate: "2019-12-31T23:59:59Z",
+				annotation.CordonUntilDate: "2019-12-31T23:59:59Z",
 			},
 		},
 	}
@@ -202,32 +202,32 @@ func Test_HasForceUpgradeAnnotation(t *testing.T) {
 
 func Test_IsCordoned(t *testing.T) {
 	tests := []struct {
-		name        string
-		chartconfig v1alpha1.ChartConfig
-		want        bool
+		name           string
+		chartconfig    v1alpha1.ChartConfig
+		expectedResult bool
 	}{
 		{
 			name: "case 0: chart cordoned",
 			chartconfig: v1alpha1.ChartConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						annotation.CordonReason:         "testing manual upgrade",
-						annotation.CordonExpirationDate: "2019-12-31T23:59:59Z",
+						annotation.CordonReason:    "testing manual upgrade",
+						annotation.CordonUntilDate: "2019-12-31T23:59:59Z",
 					},
 				},
 			},
-			want: true,
+			expectedResult: true,
 		},
 		{
-			name:        "case 1: chart did not cordon",
-			chartconfig: v1alpha1.ChartConfig{},
-			want:        false,
+			name:           "case 1: chart did not cordon",
+			chartconfig:    v1alpha1.ChartConfig{},
+			expectedResult: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsCordoned(tt.chartconfig); got != tt.want {
-				t.Errorf("IsCordoned() = %v, want %v", got, tt.want)
+			if got := IsCordoned(tt.chartconfig); got != tt.expectedResult {
+				t.Errorf("IsCordoned() = %v, want %v", got, tt.expectedResult)
 			}
 		})
 	}

--- a/service/controller/chartconfig/v7/key/key_test.go
+++ b/service/controller/chartconfig/v7/key/key_test.go
@@ -96,7 +96,7 @@ func Test_CordonReason(t *testing.T) {
 	obj := v1alpha1.ChartConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				annotation.CordonReasonAnnotationName: "manual upgrade",
+				annotation.CordonReason: "manual upgrade",
 			},
 		},
 	}
@@ -112,7 +112,7 @@ func Test_CordonUntil(t *testing.T) {
 	obj := v1alpha1.ChartConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				annotation.CordonUntilAnnotationName: "2019-12-31T23:59:59Z",
+				annotation.CordonExpirationDate: "2019-12-31T23:59:59Z",
 			},
 		},
 	}
@@ -211,8 +211,8 @@ func Test_IsCordoned(t *testing.T) {
 			chartconfig: v1alpha1.ChartConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						annotation.CordonReasonAnnotationName: "testing manual upgrade",
-						annotation.CordonUntilAnnotationName:  "2019-12-31T23:59:59Z",
+						annotation.CordonReason:         "testing manual upgrade",
+						annotation.CordonExpirationDate: "2019-12-31T23:59:59Z",
 					},
 				},
 			},

--- a/service/controller/chartconfig/v7/resource/chart/create.go
+++ b/service/controller/chartconfig/v7/resource/chart/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"k8s.io/helm/pkg/helm"
 
+	"github.com/giantswarm/chart-operator/pkg/annotation"
 	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
 )
 
@@ -18,8 +19,8 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		return microerror.Mask(err)
 	}
 
-	reason, reasonOk := customObject.Labels[key.CordonReasonAnnotationName]
-	until, untilOk := customObject.Labels[key.CordonUntilAnnotationName]
+	reason, reasonOk := customObject.Labels[annotation.CordonReasonAnnotationName]
+	until, untilOk := customObject.Labels[annotation.CordonUntilAnnotationName]
 
 	if reasonOk && untilOk {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q had been cordoned off until %s with following reason; %s ", key.ChartName(customObject), until, reason))

--- a/service/controller/chartconfig/v7/resource/chart/create.go
+++ b/service/controller/chartconfig/v7/resource/chart/create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"k8s.io/helm/pkg/helm"
 
-	"github.com/giantswarm/chart-operator/pkg/annotation"
 	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
 )
 
@@ -19,11 +18,8 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		return microerror.Mask(err)
 	}
 
-	reason, reasonOk := customObject.Labels[annotation.CordonReasonAnnotationName]
-	until, untilOk := customObject.Labels[annotation.CordonUntilAnnotationName]
-
-	if reasonOk && untilOk {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q had been cordoned off until %s with following reason; %s ", key.ChartName(customObject), until, reason))
+	if key.IsCordoned(customObject) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q had been cordoned until %s due to reason %#q ", key.ChartName(customObject), key.CordonReason(customObject), key.CordonUntil(customObject)))
 
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/chartconfig/v7/resource/chart/create.go
+++ b/service/controller/chartconfig/v7/resource/chart/create.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"k8s.io/helm/pkg/helm"
 
 	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
@@ -16,15 +15,6 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	customObject, err := key.ToCustomObject(obj)
 	if err != nil {
 		return microerror.Mask(err)
-	}
-
-	if key.IsCordoned(customObject) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q had been cordoned until %s due to reason %#q ", key.ChartName(customObject), key.CordonReason(customObject), key.CordonUntil(customObject)))
-
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-
-		return nil
 	}
 
 	chartState, err := toChartState(createChange)

--- a/service/controller/chartconfig/v7/resource/chart/current.go
+++ b/service/controller/chartconfig/v7/resource/chart/current.go
@@ -8,7 +8,6 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
-	"github.com/giantswarm/chart-operator/pkg/annotation"
 	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
 )
 
@@ -18,11 +17,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	reason, reasonOk := customObject.Labels[annotation.CordonReasonAnnotationName]
-	until, untilOk := customObject.Labels[annotation.CordonUntilAnnotationName]
-
-	if reasonOk && untilOk {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q had been cordoned off until %s with following reason; %s ", key.ChartName(customObject), until, reason))
+	if key.IsCordoned(customObject) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q had been cordoned until %s due to reason %#q ", key.ChartName(customObject), key.CordonReason(customObject), key.CordonUntil(customObject)))
 
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/chartconfig/v7/resource/chart/current.go
+++ b/service/controller/chartconfig/v7/resource/chart/current.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
+	"github.com/giantswarm/chart-operator/pkg/annotation"
 	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
 )
 
@@ -17,8 +18,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	reason, reasonOk := customObject.Labels[key.CordonReasonAnnotationName]
-	until, untilOk := customObject.Labels[key.CordonUntilAnnotationName]
+	reason, reasonOk := customObject.Labels[annotation.CordonReasonAnnotationName]
+	until, untilOk := customObject.Labels[annotation.CordonUntilAnnotationName]
 
 	if reasonOk && untilOk {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q had been cordoned off until %s with following reason; %s ", key.ChartName(customObject), until, reason))

--- a/service/controller/chartconfig/v7/resource/chart/current.go
+++ b/service/controller/chartconfig/v7/resource/chart/current.go
@@ -18,7 +18,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	if key.IsCordoned(customObject) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q had been cordoned until %s due to reason %#q ", key.ChartName(customObject), key.CordonReason(customObject), key.CordonUntil(customObject)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q has been cordoned until %#q due to reason %#q ", key.ChartName(customObject), key.CordonUntil(customObject), key.CordonReason(customObject)))
 
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/chartconfig/v7/resource/chart/current_test.go
+++ b/service/controller/chartconfig/v7/resource/chart/current_test.go
@@ -127,9 +127,9 @@ func Test_CurrentState(t *testing.T) {
 			name: "case 4: chart cordoned",
 			obj: &v1alpha1.ChartConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app-operator.giantswarm.io/cordon-reason": "testing upgrade",
-						"app-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/cordon-reason": "testing upgrade",
+						"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
 					},
 				},
 				Spec: v1alpha1.ChartConfigSpec{

--- a/service/controller/chartconfig/v7/resource/chart/current_test.go
+++ b/service/controller/chartconfig/v7/resource/chart/current_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/helmclient/helmclienttest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -121,6 +122,23 @@ func Test_CurrentState(t *testing.T) {
 			releaseHistory: &helmclient.ReleaseHistory{},
 			returnedError:  fmt.Errorf("Unexpected error"),
 			expectedError:  true,
+		},
+		{
+			name: "case 4: chart cordoned",
+			obj: &v1alpha1.ChartConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app-operator.giantswarm.io/cordon-reason": "testing upgrade",
+						"app-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
+					},
+				},
+				Spec: v1alpha1.ChartConfigSpec{
+					Chart: v1alpha1.ChartConfigSpecChart{
+						Name: "quay.io/giantswarm/chart-operator-chart",
+					},
+				},
+			},
+			expectedState: ChartState{},
 		},
 	}
 

--- a/service/controller/chartconfig/v7/version_bundle.go
+++ b/service/controller/chartconfig/v7/version_bundle.go
@@ -9,7 +9,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "chart-operator",
-				Description: "Add your changes here.",
+				Description: "checking cordon annotations in chart resource to avoid any further update.",
 				Kind:        versionbundle.KindAdded,
 			},
 		},


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/6078

This change introduces resource cancellation when controller found out resource had been cordoned off by looking into the `annotations`. 

I will apply the change only for `chartconfig/chart` at the moment. After approval, I will copy the changes to the whole resource. 

tech spec on the phase 2: https://github.com/giantswarm/giantswarm/blob/master/specs/app-catalog-phase-2.md#cordoning-managed-apps