### PR TITLE
Cancelling chart/release resource when chart had been cordon

### DIFF
--- a/service/controller/chart/v1/key/key.go
+++ b/service/controller/chart/v1/key/key.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/chart-operator/pkg/annotation"
 )
 
 const (
@@ -31,6 +33,14 @@ func ConfigMapNamespace(customResource v1alpha1.Chart) string {
 	return customResource.Spec.Config.ConfigMap.Namespace
 }
 
+func CordonReason(customObject v1alpha1.Chart) string {
+	return customObject.GetAnnotations()[annotation.CordonReason]
+}
+
+func CordonUntil(customObject v1alpha1.Chart) string {
+	return customObject.GetAnnotations()[annotation.CordonUntilDate]
+}
+
 func HasForceUpgradeAnnotation(customResource v1alpha1.Chart) bool {
 	val, ok := customResource.Annotations[ForceHelmUpgradeAnnotationName]
 	if !ok {
@@ -45,6 +55,18 @@ func HasForceUpgradeAnnotation(customResource v1alpha1.Chart) bool {
 	}
 
 	return result
+}
+
+func IsCordoned(customObject v1alpha1.Chart) bool {
+	_, reasonOk := customObject.Annotations[annotation.CordonReason]
+	_, untilOk := customObject.Annotations[annotation.CordonUntilDate]
+
+	if reasonOk && untilOk {
+		return true
+	} else {
+		return false
+	}
+
 }
 
 func IsDeleted(customResource v1alpha1.Chart) bool {

--- a/service/controller/chart/v1/key/key.go
+++ b/service/controller/chart/v1/key/key.go
@@ -33,12 +33,12 @@ func ConfigMapNamespace(customResource v1alpha1.Chart) string {
 	return customResource.Spec.Config.ConfigMap.Namespace
 }
 
-func CordonReason(customObject v1alpha1.Chart) string {
-	return customObject.GetAnnotations()[annotation.CordonReason]
+func CordonReason(customResource v1alpha1.Chart) string {
+	return customResource.GetAnnotations()[annotation.CordonReason]
 }
 
-func CordonUntil(customObject v1alpha1.Chart) string {
-	return customObject.GetAnnotations()[annotation.CordonUntilDate]
+func CordonUntil(customResource v1alpha1.Chart) string {
+	return customResource.GetAnnotations()[annotation.CordonUntilDate]
 }
 
 func HasForceUpgradeAnnotation(customResource v1alpha1.Chart) bool {
@@ -57,9 +57,9 @@ func HasForceUpgradeAnnotation(customResource v1alpha1.Chart) bool {
 	return result
 }
 
-func IsCordoned(customObject v1alpha1.Chart) bool {
-	_, reasonOk := customObject.Annotations[annotation.CordonReason]
-	_, untilOk := customObject.Annotations[annotation.CordonUntilDate]
+func IsCordoned(customResource v1alpha1.Chart) bool {
+	_, reasonOk := customResource.Annotations[annotation.CordonReason]
+	_, untilOk := customResource.Annotations[annotation.CordonUntilDate]
 
 	if reasonOk && untilOk {
 		return true

--- a/service/controller/chart/v1/resource/release/current.go
+++ b/service/controller/chart/v1/resource/release/current.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/key"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/chart/v1/resource/release/current.go
+++ b/service/controller/chart/v1/resource/release/current.go
@@ -2,17 +2,28 @@ package release
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/key"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
 	cr, err := key.ToCustomResource(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	if key.IsCordoned(cr) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q has been cordoned until %#q due to reason %#q ", key.ReleaseName(cr), key.CordonUntil(cr), key.CordonReason(cr)))
+
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil, nil
 	}
 
 	releaseName := key.ReleaseName(cr)

--- a/service/controller/chart/v1/resource/release/current_test.go
+++ b/service/controller/chart/v1/resource/release/current_test.go
@@ -112,6 +112,21 @@ func Test_CurrentState(t *testing.T) {
 			returnedError:  fmt.Errorf("Unexpected error"),
 			expectedError:  true,
 		},
+		{
+			name: "case 4: chart cordoned",
+			obj: &v1alpha1.Chart{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/cordon-reason": "testing upgrade",
+						"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
+					},
+				},
+				Spec: v1alpha1.ChartSpec{
+					Name: "quay.io/giantswarm/chart-operator-chart",
+				},
+			},
+			expectedState: ReleaseState{},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Toward giantswarm/giantswarm#6078

Do the same practice as https://github.com/giantswarm/chart-operator/pull/250, but applied into `chart/release` resource. 