### PR TITLE
Allow all external traffic

### DIFF
--- a/helm/chart-operator-chart/templates/np.yaml
+++ b/helm/chart-operator-chart/templates/np.yaml
@@ -15,13 +15,7 @@ spec:
     - port: {{ .Values.port }}
       protocol: TCP
   egress:
-  - to:
-    - ipBlock:
-        cidr: 10.0.0.0/8
-    - ipBlock:
-        cidr: 172.16.0.0/12
-    - ipBlock:
-        cidr: 192.168.0.0/16
+  - {}
   policyTypes:
   - Egress
   - Ingress


### PR DESCRIPTION
chart-operator uses chart-repo to get charts 