### PR TITLE
Changing all v6 into v7 from v7 directory

### DIFF
--- a/service/controller/chartconfig/v7/resource/chart/desired.go
+++ b/service/controller/chartconfig/v7/resource/chart/desired.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v6/key"
+	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/chartconfig/v7/resource/chart/update.go
+++ b/service/controller/chartconfig/v7/resource/chart/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"k8s.io/helm/pkg/helm"
 
-	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v6/key"
+	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {

--- a/service/controller/chartconfig/v7/resource/chartstatus/create.go
+++ b/service/controller/chartconfig/v7/resource/chartstatus/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v6/key"
+	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {

--- a/service/controller/chartconfig/v7/resource_set.go
+++ b/service/controller/chartconfig/v7/resource_set.go
@@ -14,10 +14,10 @@ import (
 	"github.com/spf13/afero"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v6/key"
-	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v6/resource/chart"
-	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v6/resource/chartstatus"
-	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v6/resource/tiller"
+	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
+	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/resource/chart"
+	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/resource/chartstatus"
+	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/resource/tiller"
 )
 
 // ResourceSetConfig contains necessary dependencies and settings for


### PR DESCRIPTION
Following the discussion from here: https://github.com/giantswarm/chart-operator/pull/252#discussion_r300564225

> Do you maybe want to check all the imports and provide a separate PR for this so we get over it now? It looks to me now that this is not some single accident but that we apparently missed to do this properly.