### PR TITLE
Change the metric name to follow `_seconds`

### DIFF
--- a/service/collector/chart_resource.go
+++ b/service/collector/chart_resource.go
@@ -28,7 +28,7 @@ var (
 	)
 
 	cordonExpireTimeDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(Namespace, "", "cordon_expire_time"),
+		prometheus.BuildFQName(Namespace, "", "cordon_expire_time_seconds"),
 		"A metric of the expire time of cordoned chartconfig as unix seconds.",
 		[]string{
 			labelChart,


### PR DESCRIPTION
Follow suggestion form @kopiczko https://github.com/giantswarm/chart-operator/pull/255#discussion_r302108915

> I think it would be good to add _seconds here https://prometheus.io/docs/practices/naming/
