### PR TITLE
Fix ambiguous metrics naming; from apps,charts to chartConfigs

### DIFF
--- a/service/collector/chart_config_resource.go
+++ b/service/collector/chart_config_resource.go
@@ -27,8 +27,8 @@ var (
 		nil,
 	)
 
-	cordonExpireTimeDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(Namespace, "", "cordon_expire_time_seconds"),
+	chartConfigCordonExpireTimeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "chartconfig_cordon_expire_time_seconds"),
 		"A metric of the expire time of cordoned chartconfig as unix seconds.",
 		[]string{
 			labelChart,
@@ -97,7 +97,7 @@ func (c *ChartConfigResource) Collect(ch chan<- prometheus.Metric) error {
 		}
 
 		ch <- prometheus.MustNewConstMetric(
-			cordonExpireTimeDesc,
+			chartConfigCordonExpireTimeDesc,
 			prometheus.GaugeValue,
 			float64(t.Unix()),
 			key.ChartName(chartConfig),
@@ -112,7 +112,7 @@ func (c *ChartConfigResource) Collect(ch chan<- prometheus.Metric) error {
 // Describe emits the description for the metrics collected here.
 func (a *ChartConfigResource) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- chartConfigDesc
-	ch <- cordonExpireTimeDesc
+	ch <- chartConfigCordonExpireTimeDesc
 	return nil
 }
 

--- a/service/collector/chart_config_resource.go
+++ b/service/collector/chart_config_resource.go
@@ -37,20 +37,20 @@ var (
 	)
 )
 
-// ChartResourceConfig is this collector's configuration struct.
-type ChartResourceConfig struct {
+// ChartConfigResourceConfig is this collector's configuration struct.
+type ChartConfigResourceConfig struct {
 	G8sClient versioned.Interface
 	Logger    micrologger.Logger
 }
 
-// ChartResource is the main struct for this collector.
-type ChartResource struct {
+// ChartConfigResource is the main struct for this collector.
+type ChartConfigResource struct {
 	g8sClient versioned.Interface
 	logger    micrologger.Logger
 }
 
-// NewChartResource creates a new ChartResource metrics collector.
-func NewChartResource(config ChartResourceConfig) (*ChartResource, error) {
+// NewChartConfigResource creates a new ChartConfigResource metrics collector.
+func NewChartConfigResource(config ChartConfigResourceConfig) (*ChartConfigResource, error) {
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
@@ -58,7 +58,7 @@ func NewChartResource(config ChartResourceConfig) (*ChartResource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	a := &ChartResource{
+	a := &ChartConfigResource{
 		g8sClient: config.G8sClient,
 		logger:    config.Logger,
 	}
@@ -66,7 +66,7 @@ func NewChartResource(config ChartResourceConfig) (*ChartResource, error) {
 	return a, nil
 }
 
-func (c *ChartResource) Collect(ch chan<- prometheus.Metric) error {
+func (c *ChartConfigResource) Collect(ch chan<- prometheus.Metric) error {
 	c.logger.Log("level", "debug", "message", "collecting metrics for ChartConfigs")
 
 	chartConfigs, err := c.g8sClient.CoreV1alpha1().ChartConfigs("").List(metav1.ListOptions{})
@@ -110,7 +110,7 @@ func (c *ChartResource) Collect(ch chan<- prometheus.Metric) error {
 }
 
 // Describe emits the description for the metrics collected here.
-func (a *ChartResource) Describe(ch chan<- *prometheus.Desc) error {
+func (a *ChartConfigResource) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- chartConfigDesc
 	return nil
 }

--- a/service/collector/chart_config_resource.go
+++ b/service/collector/chart_config_resource.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	chartConfigDesc *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(Namespace, "", "chartconfig_status"),
+		prometheus.BuildFQName(Namespace, "chartconfig", "status"),
 		"Managed charts status.",
 		[]string{
 			labelChart,
@@ -28,7 +28,7 @@ var (
 	)
 
 	chartConfigCordonExpireTimeDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(Namespace, "", "chartconfig_cordon_expire_time_seconds"),
+		prometheus.BuildFQName(Namespace, "chartconfig", "cordon_expire_time_seconds"),
 		"A metric of the expire time of cordoned chartconfig as unix seconds.",
 		[]string{
 			labelChart,

--- a/service/collector/chart_config_resource.go
+++ b/service/collector/chart_config_resource.go
@@ -112,6 +112,7 @@ func (c *ChartConfigResource) Collect(ch chan<- prometheus.Metric) error {
 // Describe emits the description for the metrics collected here.
 func (a *ChartConfigResource) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- chartConfigDesc
+	ch <- cordonExpireTimeDesc
 	return nil
 }
 

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -45,14 +45,14 @@ func NewSet(config SetConfig) (*Set, error) {
 
 	var err error
 
-	var chartResourceCollector *ChartResource
+	var chartConfigResourceCollector *ChartConfigResource
 	{
-		c := ChartResourceConfig{
+		c := ChartConfigResourceConfig{
 			G8sClient: config.G8sClient,
 			Logger:    config.Logger,
 		}
 
-		chartResourceCollector, err = NewChartResource(c)
+		chartConfigResourceCollector, err = NewChartConfigResource(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -94,7 +94,7 @@ func NewSet(config SetConfig) (*Set, error) {
 	{
 		c := collector.SetConfig{
 			Collectors: []collector.Interface{
-				chartResourceCollector,
+				chartConfigResourceCollector,
 				tillerMaxHistoryCollector,
 				tillerReachableCollector,
 			},


### PR DESCRIPTION
Toward giantswarm/giantswarm#6078

Before I jump into `chart` metrics against cordon support, we might need renaming from either `chart` or `app` to `chartConfigs`. 

this is the clean-up stage before we actually go into the implementation of cordon metrics support in `chart` CR. 