### PR TITLE
Parsing cordon timestamp with correct format

### DIFF
--- a/service/collector/chart_config_resource.go
+++ b/service/collector/chart_config_resource.go
@@ -122,12 +122,12 @@ func convertToTime(datetime string) (time.Time, error) {
 
 	split := strings.Split(datetime, ".")
 	if len(split) == 0 {
-		return time.Time{}, microerror.Maskf(invalidExecutionError, "'%#v' must have at least one item in order to collect metrics for the cordon expiration", datetime)
+		return time.Time{}, microerror.Maskf(invalidExecutionError, "%#q must have at least one item in order to collect metrics for the cordon expiration", datetime)
 	}
 
 	t, err := time.Parse(layout, split[0])
 	if err != nil {
-		return time.Time{}, microerror.Mask(err)
+		return time.Time{}, microerror.Maskf(invalidExecutionError, "unavailable to %#q parsing: %#v", split[0], err.Error())
 	}
 
 	return t, nil

--- a/service/collector/chart_config_resource.go
+++ b/service/collector/chart_config_resource.go
@@ -126,7 +126,6 @@ func convertToTime(datetime string) (time.Time, error) {
 	}
 
 	t, err := time.Parse(layout, split[0])
-
 	if err != nil {
 		return time.Time{}, microerror.Mask(err)
 	}

--- a/service/collector/chart_config_resource.go
+++ b/service/collector/chart_config_resource.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
@@ -117,8 +118,14 @@ func (a *ChartConfigResource) Describe(ch chan<- *prometheus.Desc) error {
 }
 
 func convertToTime(datetime string) (time.Time, error) {
-	layout := "2006-01-02T15:04:05.000Z"
-	t, err := time.Parse(layout, datetime)
+	layout := "2006-01-02T15:04:05"
+
+	split := strings.Split(datetime, ".")
+	if len(split) == 0 {
+		return time.Time{}, microerror.Maskf(invalidExecutionError, "'%#v' must have at least one item in order to collect metrics for the cordon expiration", datetime)
+	}
+
+	t, err := time.Parse(layout, split[0])
 
 	if err != nil {
 		return time.Time{}, microerror.Mask(err)

--- a/service/collector/chart_config_resource_test.go
+++ b/service/collector/chart_config_resource_test.go
@@ -1,0 +1,49 @@
+package collector
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_convertToTime(t *testing.T) {
+	expectedTime, err := time.Parse(time.RFC3339, "2019-12-31T23:59:59Z")
+	if err != nil {
+		t.Errorf("time.Parse err = %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		datetime     string
+		expected     time.Time
+		errorMatcher func(error) bool
+	}{
+		{
+			name:     "case 1: normal timestamp parsing",
+			datetime: "2019-12-31T23:59:59.000",
+			expected: expectedTime,
+		},
+		{
+			name:         "case 2: parsing error since unknown ",
+			datetime:     "2019-12-31T23:59:59Z",
+			errorMatcher: IsInvalidExecution,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := convertToTime(tc.datetime)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("convertToTime() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
To fix the issue in https://github.com/giantswarm/app-operator/pull/105#issuecomment-511680126

```
W 07/16 06:10:40 could not convert cordon-until | chart-operator/service/collector/chart_resource.go:71
	/go/src/github.com/giantswarm/chart-operator/service/collector/chart_config_resource.go:124:
	parsing time "2019-12-31T23:59:59Z" as "2006-01-02T15:04:05.000Z": cannot parse "Z" as ".000"
D 07/16 06:10:40 finished collecting metrics for Charts | chart-operator/service/collector/chart_resource.go:83
D 07/16 06:10:40 finished collecting Tiller max history | chart-operator/service/collector/tiller_max_history.go:110
D 07/16 06:10:40 finished collecting Tiller reachability | chart-operator/service/collector/tiller_reachable.go:113
D 07/16 06:10:40 collected metrics | exporterkit/collector/set.go:95
D 07/16 06:10:41 collected metrics | exporterkit/collector/set.go:95
D 07/16 06:11:13 collecting metrics | exporterkit/collector/set.go:73
D 07/16 06:11:13 collecting Tiller reachability | chart-operator/service/collector/tiller_reachable.go:76
D 07/16 06:11:13 collecting metrics | exporterkit/collector/set.go:73
D 07/16 06:11:13 collecting metrics for Charts | chart-operator/service/collector/chart_resource.go:56
D 07/16 06:11:13 collecting metrics for ChartConfigs | chart-operator/service/collector/chart_config_resource.go:70
D 07/16 06:11:13 collecting Tiller max history | chart-operator/service/collector/tiller_max_history.go:77
W 07/16 06:11:13 could not convert cordon-until | chart-operator/service/collector/chart_resource.go:71
	/go/src/github.com/giantswarm/chart-operator/service/collector/chart_config_resource.go:124:
	parsing time "2019-12-31T23:59:59Z" as "2006-01-02T15:04:05.000Z": cannot parse "Z" as ".000"
```