### PR TITLE
Remove executionFailedError matchers to align with fmt

### DIFF
--- a/integration/cnr/error.go
+++ b/integration/cnr/error.go
@@ -4,11 +4,14 @@ package cnr
 
 import "github.com/giantswarm/microerror"
 
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
-}
-
-// IsExecutionFailed asserts executionFailedError.
-func IsExecutionFailed(err error) bool {
-	return microerror.Cause(err) == executionFailedError
 }


### PR DESCRIPTION
https://github.com/giantswarm/giantswarm/issues/6569