### PR TITLE
Bump release channel to 0-9-stable

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.8.0
+version: 0.9.0


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6280

To mitigate the linked PM we use the WIP version of chart-operator in cluster-operator.

The actual fix is to move the bootstrapping to app-operator and stop using the release channels mess. I will do that as soon as I'm able to work again on phase 2 of App Catalog.