### PR TITLE
Update tags trigger on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - build
+      - build:
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,9 @@ workflows:
   build:
     jobs:
       - build
+        filters:
+          tags:
+            only: /^v.*/
 
       - architect/push-to-docker:
           name: push-chart-operator-to-docker


### PR DESCRIPTION
Found an issue with workflow dependencies, 
`architect/push-to-app-catalog` waits for `build` but that's not triggered by git tag. 