### PR TITLE
Use patch for annotations not update

### DIFF
--- a/service/controller/chart/v1/resource/release/create.go
+++ b/service/controller/chart/v1/resource/release/create.go
@@ -45,7 +45,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			return microerror.Mask(err)
 		}
 
-		err = r.updateAnnotations(ctx, cr, releaseState)
+		err = r.patchAnnotations(ctx, cr, releaseState)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/chart/v1/resource/release/types.go
+++ b/service/controller/chart/v1/resource/release/types.go
@@ -1,5 +1,11 @@
 package release
 
+type Patch struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
 // ReleaseState holds the state of the Helm release to be reconciled.
 type ReleaseState struct {
 	// Name is the name of the Helm release when the chart is deployed.

--- a/service/controller/chart/v1/resource/release/update.go
+++ b/service/controller/chart/v1/resource/release/update.go
@@ -48,7 +48,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			return microerror.Mask(err)
 		}
 
-		err = r.updateAnnotations(ctx, cr, releaseState)
+		err = r.patchAnnotations(ctx, cr, releaseState)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6696

The `values-md5-checksum` annotation is now set via a patch operation. This is safer because both chart-operator and app-operator need to set annotations.

See giantswarm/giantswarm#6696 (comment).