### PR TITLE
Add empty annotations to patch when none are present

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -133,7 +133,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:bfe79969162c245c57fc564c53ed469e537d184e04bec9dffb9637796f7c6770"
+  digest = "1:a4b4574e383aa6611b304fb09ee3679aa55787509e906f644198eb5d1e749aea"
   name = "github.com/giantswarm/apiextensions"
   packages = [
     "pkg/apis/application/v1alpha1",
@@ -156,7 +156,7 @@
     "pkg/clientset/versioned/typed/release/v1alpha1/fake",
   ]
   pruneopts = "UT"
-  revision = "7f178f7ebd4566ad4eb1dd5a8f83ede5b20ba978"
+  revision = "8c3ef80abe83a1b10557b8c2891c85eb4b4eb061"
 
 [[projects]]
   branch = "master"
@@ -354,12 +354,11 @@
   revision = "c91a5899eae8867e7966df734f4cccbba450c841"
 
 [[projects]]
-  digest = "1:9db6e7ab54d909d92bebfec495fd679bd3af1a6ba0b22d7da72edb23347dddb9"
+  digest = "1:83a37f3bd4ccd13469775ef771e943e6c7cfaba6926decff6c83135e56512f08"
   name = "github.com/go-kit/kit"
   packages = [
     "endpoint",
     "log",
-    "transport",
     "transport/http",
   ]
   pruneopts = "UT"

--- a/service/controller/chart/v1/resource/release/resource.go
+++ b/service/controller/chart/v1/resource/release/resource.go
@@ -112,13 +112,21 @@ func (r *Resource) patchAnnotations(ctx context.Context, cr v1alpha1.Chart, rele
 	currentChecksum := key.ValuesMD5ChecksumAnnotation(*currentCR)
 
 	if releaseState.ValuesMD5Checksum != currentChecksum {
-		patches := []Patch{
-			{
+		patches := []Patch{}
+
+		if len(cr.Annotations) == 0 {
+			patches = append(patches, Patch{
 				Op:    "add",
-				Path:  fmt.Sprintf("/metadata/annotations/%s", replaceToEscape(key.ValuesMD5ChecksumAnnotationName)),
-				Value: releaseState.ValuesMD5Checksum,
-			},
+				Path:  "/metadata/annotations",
+				Value: map[string]string{},
+			})
 		}
+
+		patches = append(patches, Patch{
+			Op:    "add",
+			Path:  fmt.Sprintf("/metadata/annotations/%s", replaceToEscape(key.ValuesMD5ChecksumAnnotationName)),
+			Value: releaseState.ValuesMD5Checksum,
+		})
 
 		bytes, err := json.Marshal(patches)
 		if err != nil {

--- a/service/controller/chart/v1/resource/release/resource.go
+++ b/service/controller/chart/v1/resource/release/resource.go
@@ -114,7 +114,7 @@ func (r *Resource) patchAnnotations(ctx context.Context, cr v1alpha1.Chart, rele
 	if releaseState.ValuesMD5Checksum != currentChecksum {
 		patches := []Patch{}
 
-		if len(cr.Annotations) == 0 {
+		if len(currentCR.Annotations) == 0 {
 			patches = append(patches, Patch{
 				Op:    "add",
 				Path:  "/metadata/annotations",

--- a/service/controller/chart/v1/resource/status/create.go
+++ b/service/controller/chart/v1/resource/status/create.go
@@ -76,7 +76,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		currentCR.Status = desiredStatus
 
-		_, err = r.g8sClient.ApplicationV1alpha1().Charts(cr.Namespace).UpdateStatus(currentCR)
+		_, err = r.g8sClient.ApplicationV1alpha1().Charts(cr.Namespace).Update(currentCR)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/chart/v1/resource/status/create.go
+++ b/service/controller/chart/v1/resource/status/create.go
@@ -76,7 +76,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		currentCR.Status = desiredStatus
 
-		_, err = r.g8sClient.ApplicationV1alpha1().Charts(cr.Namespace).Update(currentCR)
+		_, err = r.g8sClient.ApplicationV1alpha1().Charts(cr.Namespace).UpdateStatus(currentCR)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/vendor/github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1/chart_types.go
+++ b/vendor/github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1/chart_types.go
@@ -23,6 +23,8 @@ spec:
     kind: Chart
     plural: charts
     singular: chart
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/vendor/github.com/go-kit/kit/transport/doc.go
+++ b/vendor/github.com/go-kit/kit/transport/doc.go
@@ -1,2 +1,0 @@
-// Package transport contains bindings to concrete transports.
-package transport


### PR DESCRIPTION
Towards giantswarm/giantswarm#6800

Fixes a problem found when testing the kube-state-metrics migration. 