### PR TITLE
Check CR status in e2e test

### DIFF
--- a/integration/key/chart_custom_resource.go
+++ b/integration/key/chart_custom_resource.go
@@ -1,9 +1,0 @@
-package key
-
-func ChartCRName() string {
-	return "myapp"
-}
-
-func ChartCRNamespace() string {
-	return "giantswarm"
-}

--- a/integration/key/chart_custom_resource.go
+++ b/integration/key/chart_custom_resource.go
@@ -1,0 +1,9 @@
+package key
+
+func ChartCRName() string {
+	return "myapp"
+}
+
+func ChartCRNamespace() string {
+	return "giantswarm"
+}

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/giantswarm/e2e-harness/pkg/release"
 	"github.com/giantswarm/e2etemplates/pkg/chartvalues"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/chart-operator/integration/key"
 )
@@ -76,7 +77,7 @@ func TestChartLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking status for chart CR %#q", key.ChartCRName()))
 
-		cr, err := config.K8sClients().G8sClient().ApplicationV1alpha1().Charts(key.ChartCRNamespace()).Get(key.ChartCRName(), metav1.GetOptions{})
+		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.ChartCRNamespace()).Get(key.ChartCRName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -77,7 +77,7 @@ func TestChartLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking status for chart CR %#q", key.ChartCRName()))
 
-		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.ChartCRNamespace()).Get(key.ChartCRName(), metav1.GetOptions{})
+		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -75,7 +75,7 @@ func TestChartLifecycle(t *testing.T) {
 
 	// Check chart CR status.
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking status for chart CR %#q", key.ChartCRName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking status for chart CR %#q", key.TestAppReleaseName()))
 
 		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
@@ -85,7 +85,7 @@ func TestChartLifecycle(t *testing.T) {
 			t.Fatalf("expected CR release status %#q got %#q", "DEPLOYED", cr.Status.Release.Status)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checked status for chart CR %#q", key.ChartCRName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checked status for chart CR %#q", key.TestAppReleaseName()))
 	}
 
 	// Test update.

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -72,6 +72,21 @@ func TestChartLifecycle(t *testing.T) {
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q is deployed", key.TestAppReleaseName()))
 	}
 
+	// Check chart CR status.
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking status for chart CR %#q", key.ChartCRName()))
+
+		cr, err := config.K8sClients().G8sClient().ApplicationV1alpha1().Charts(key.ChartCRNamespace()).Get(key.ChartCRName(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+		if cr.Status.Release.Status != "DEPLOYED" {
+			t.Fatalf("expected CR release status %#q got %#q", "DEPLOYED", cr.Status.Release.Status)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checked status for chart CR %#q", key.ChartCRName()))
+	}
+
 	// Test update.
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart %#q", key.CustomResourceReleaseName()))


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/apiextensions/pull/276. The status subresource was missing from the chard CRD which broke the status resource.

Before we just checked the test chart has status deployed. Now we also check the status is in the chart CR status.
