### PR TITLE
Add clusterrole and binding for PSP to app catalog chart

### DIFF
--- a/helm/chart-operator/templates/psp.yaml
+++ b/helm/chart-operator/templates/psp.yaml
@@ -28,3 +28,36 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.name }}-psp-user
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ .Values.name }}-psp
+  verbs:
+  - use
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.name }}-psp
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.name }}-psp-user
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixes a problem found during testing upgrade of 8.4.0 to 8.5.0. The `chart-operator` chart for App Catalog misses the cluster role and binding present in `chart-operator-chart` for appr.