### PR TITLE
Use default-catalog not giantswarm-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,8 +182,8 @@ workflows:
 
       - architect/push-to-app-catalog:
           name: push-chart-operator-to-app-catalog
-          app_catalog: "giantswarm-catalog"
-          app_catalog_test: "giantswarm-test-catalog"
+          app_catalog: "default-catalog"
+          app_catalog_test: "default-test-catalog"
           chart: "chart-operator"
           requires:
             - push-chart-operator-to-docker


### PR DESCRIPTION
During onsite discussions, we identified that we need another app catalog. https://github.com/giantswarm/giantswarm-catalog should only be for optional apps with an SLA that customers can choose to install.

For the apps we install in tenant clusters we use the new https://github.com/giantswarm/default-catalog.

