### PR TITLE
Fix chart-operator chart templating

### DIFF
--- a/helm/chart-operator/templates/configmap.yaml
+++ b/helm/chart-operator/templates/configmap.yaml
@@ -16,9 +16,9 @@ data:
         address: 'http://0.0.0.0:{{ .Values.pod.port }}'
     service:
       cnr:
-        address: '{{ .Values.resource.cnr.address }}'
+        address: '{{ .Values.cnr.address }}'
       helm:
-        tillerNamespace:  '{{ .Values.resource.tiller.namespace }}'
+        tillerNamespace:  '{{ .Values.tiller.namespace }}'
       kubernetes:
         incluster: true
         watch:

--- a/helm/chart-operator/templates/psp.yaml
+++ b/helm/chart-operator/templates/psp.yaml
@@ -32,7 +32,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.resource.default.name }}-psp-user
+  name: {{ tpl .Values.resource.default.name . }}-psp-user
   labels:
     app: {{ .Values.project.name }}
     giantswarm.io/service-type: "managed"
@@ -42,22 +42,22 @@ rules:
   resources:
   - podsecuritypolicies
   resourceNames:
-  - {{ .Values.resource.default.name }}-psp
+  - {{ tpl .Values.resource.default.name . }}-psp
   verbs:
   - use
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.resource.default.name }}-psp
+  name: {{ tpl .Values.resource.default.name . }}-psp
   labels:
     app: {{ .Values.project.name }}
     giantswarm.io/service-type: "managed"
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.resource.default.name }}
+  name: {{ tpl .Values.resource.default.name . }}
   namespace: {{ .Values.resource.default.namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.resource.default.name }}-psp-user
+  name: {{ tpl .Values.resource.default.name . }}-psp-user
   apiGroup: rbac.authorization.k8s.io

--- a/helm/chart-operator/templates/psp.yaml
+++ b/helm/chart-operator/templates/psp.yaml
@@ -49,7 +49,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ tpl .Values.resource.default.name . }}-psp
+  name: {{ tpl .Values.resource.default.name . }}-psp-user
   labels:
     app: {{ .Values.project.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -1,8 +1,13 @@
 clusterDNSIP: 172.31.0.10
+  
+cnr:
+  address: https://quay.io
+
 image:
   registry: "quay.io"
   repository: "giantswarm/chart-operator"
   tag: "[[ .Version ]]"
+
 pod:
   user:
     id: 1000
@@ -10,8 +15,10 @@ pod:
     id: 1000
   port: 8000
   replicas: 1
+
 project:
   name: "chart-operator"
+
 # Resource names are truncated to 47 characters. Kubernetes allows 63 characters
 # limit for resource names. When pods for deployments are created they have
 # additional 16 characters suffix, e.g. "-957c9d6ff-pkzgw" and we want to have
@@ -24,12 +31,11 @@ project:
 #     {{ tpl .Values.resource.default.name . }}.
 #
 resource:
-  cnr:
-    address: https://quay.io
   default:
     name: '{{ .Release.Name | replace "." "-" | trunc 47 }}'
     namespace: "giantswarm"
   psp:
     name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-psp'
-  tiller:
-    namespace: "kube-system"
+
+tiller:
+  namespace: "kube-system"


### PR DESCRIPTION
The templating in the App Catalog chart was incorrect. The resource values are just for ensuing multiple instances of the operator can be installed.

Aligns with the appr chart. https://github.com/giantswarm/chart-operator/blob/5440b976e74d41bc06fd6a133356bd2dfae214ea/helm/chart-operator-chart/values.yaml