### PR TITLE
Add init container to wait for quay.io to be resolvable

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -179,7 +179,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6c25bce0a15e2f819db2f79d1c3915670b5a4e02f575ec39a447598c74c6cdda"
+  digest = "1:f86c1d26e7a8575e6e33f376181d4e5df074a4d560463cf9b5375b4a23b64fa5"
   name = "github.com/giantswarm/e2e-harness"
   packages = [
     "internal/filelogger",
@@ -189,7 +189,7 @@
     "pkg/release",
   ]
   pruneopts = "UT"
-  revision = "094ac65a5e97510adafec48e7bb35944b9e346e8"
+  revision = "c1a50838e28717223b994d1f3607d249553e4343"
 
 [[projects]]
   branch = "master"
@@ -1286,6 +1286,7 @@
     "github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext",
     "github.com/giantswarm/operatorkit/flag/service/kubernetes",
     "github.com/giantswarm/operatorkit/informer",
+    "github.com/giantswarm/operatorkit/resource",
     "github.com/giantswarm/operatorkit/resource/wrapper/metricsresource",
     "github.com/giantswarm/operatorkit/resource/wrapper/retryresource",
     "github.com/giantswarm/versionbundle",

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       dnsConfig:
         nameservers:
         - {{ .Values.clusterDNSIP }}
-        - 8.8.8.8
+        - {{ .Values.externalDNSIP }}
         searches:
         - giantswarm.svc.cluster.local
         - svc.cluster.local
@@ -56,6 +56,16 @@ spec:
         options:
         - name: ndots
           value: "5"
+      initContainers:
+      - name: wait-for-quay
+        image: quay.io/giantswarm/alpine:3.10-giantswarm
+        command: 
+        - sh
+        - -c
+        - until nslookup quay.io. {{ .Values.externalDNSIP }}; do echo waiting for quay.io; sleep 2; done;
+        securityContext:
+          runAsUser: {{ .Values.pod.user.id }}
+          runAsGroup: {{ .Values.pod.group.id }}
       containers:
       - name: {{ .Values.project.name }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/chart-operator/templates/psp.yaml
+++ b/helm/chart-operator/templates/psp.yaml
@@ -1,3 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ tpl .Values.resource.default.name . }}-psp-user
+  labels:
+    app: {{ .Values.project.name }}
+    giantswarm.io/service-type: "managed"
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ tpl .Values.resource.default.name . }}-psp
+  verbs:
+  - use
+---
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -29,23 +46,6 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ tpl .Values.resource.default.name . }}-psp-user
-  labels:
-    app: {{ .Values.project.name }}
-    giantswarm.io/service-type: "managed"
-rules:
-- apiGroups:
-  - extensions
-  resources:
-  - podsecuritypolicies
-  resourceNames:
-  - {{ tpl .Values.resource.default.name . }}-psp
-  verbs:
-  - use
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -3,6 +3,8 @@ clusterDNSIP: 172.31.0.10
 cnr:
   address: https://quay.io
 
+externalDNSIP: 8.8.8.8
+
 image:
   registry: "quay.io"
   repository: "giantswarm/chart-operator"

--- a/service/controller/chartconfig/v7/resource/chart/create.go
+++ b/service/controller/chartconfig/v7/resource/chart/create.go
@@ -58,8 +58,6 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			return microerror.Mask(err)
 		}
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart %#q", chartState.ChartName))
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not creating chart %#q", chartState.ChartName))
 	}
 
 	return nil

--- a/service/controller/chartconfig/v7/resource/chart/update.go
+++ b/service/controller/chartconfig/v7/resource/chart/update.go
@@ -58,10 +58,8 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			return microerror.Mask(err)
 		}
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart %#q", chartState.ChartName))
-
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q does not need to be updated", chartState.ChartName))
 	}
+
 	return nil
 }
 

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/framework/version_bundle.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/framework/version_bundle.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	defaultOwner = "giantswarm"
-	defaultRepo  = "installations"
+	defaultRepo  = "releases"
 )
 
 // VBVParams holds information which we can use to query  versionbundle
@@ -93,7 +93,7 @@ func getContent(provider, token string) (string, error) {
 
 	client := github.NewClient(tc)
 
-	path := fmt.Sprintf("release/provider/%s.yaml", provider)
+	path := fmt.Sprintf("%s.yaml", provider)
 	opt := &github.RepositoryContentGetOptions{}
 	repoContent, _, _, err := client.Repositories.GetContents(ctx, defaultOwner, defaultRepo, path, opt)
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6800

- Adds an init container which waits for quay.io to be resolvable using 8.8.8.8.
- This is because chart-operator has its own DNS settings so it can install coredns in new tenant clusters.