### PR TITLE
Remove dupe clusterrole and binding

### DIFF
--- a/helm/chart-operator/templates/psp.yaml
+++ b/helm/chart-operator/templates/psp.yaml
@@ -1,20 +1,3 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ tpl .Values.resource.default.name . }}-psp-user
-  labels:
-    app: {{ .Values.project.name }}
-    giantswarm.io/service-type: "managed"
-rules:
-- apiGroups:
-  - extensions
-  resources:
-  - podsecuritypolicies
-  resourceNames:
-  - {{ tpl .Values.resource.default.name . }}-psp
-  verbs:
-  - use
----
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -46,19 +29,3 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ tpl .Values.resource.default.name . }}-psp-user
-  labels:
-    app: {{ .Values.project.name }}
-    giantswarm.io/service-type: "managed"
-subjects:
-- kind: ServiceAccount
-  name: {{ tpl .Values.resource.default.name . }}
-  namespace: {{ .Values.resource.default.namespace }}
-roleRef:
-  kind: ClusterRole
-  name: {{ tpl .Values.resource.default.name . }}-psp-user
-  apiGroup: rbac.authorization.k8s.io

--- a/helm/chart-operator/templates/rbac.yaml
+++ b/helm/chart-operator/templates/rbac.yaml
@@ -151,7 +151,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ tpl .Values.resource.psp.name . }}-user
   labels:
     app: {{ .Values.project.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/chart-operator/templates/rbac.yaml
+++ b/helm/chart-operator/templates/rbac.yaml
@@ -130,3 +130,36 @@ roleRef:
   kind: ClusterRole
   name: {{ tpl .Values.resource.default.name  . }}
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    app: {{ .Values.project.name }}
+    giantswarm.io/service-type: "managed"
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ tpl .Values.resource.psp.name . }}
+    verbs:
+      - use
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    app: {{ .Values.project.name }}
+    giantswarm.io/service-type: "managed"
+subjects:
+  - kind: ServiceAccount
+    name: {{ tpl .Values.resource.default.name  . }}
+    namespace: {{ tpl .Values.resource.default.namespace . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ tpl .Values.resource.psp.name . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/chart-operator/templates/rbac.yaml
+++ b/helm/chart-operator/templates/rbac.yaml
@@ -130,36 +130,3 @@ roleRef:
   kind: ClusterRole
   name: {{ tpl .Values.resource.default.name  . }}
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
-  labels:
-    app: {{ .Values.project.name }}
-    giantswarm.io/service-type: "managed"
-rules:
-  - apiGroups:
-      - extensions
-    resources:
-      - podsecuritypolicies
-    resourceNames:
-      - {{ tpl .Values.resource.psp.name . }}
-    verbs:
-      - use
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
-  labels:
-    app: {{ .Values.project.name }}
-    giantswarm.io/service-type: "managed"
-subjects:
-  - kind: ServiceAccount
-    name: {{ tpl .Values.resource.default.name  . }}
-    namespace: {{ tpl .Values.resource.default.namespace . }}
-roleRef:
-  kind: ClusterRole
-  name: {{ tpl .Values.resource.psp.name . }}
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Upgrading 8.2.0 > 8.5.0 breaks `chart-operator` as it complains about `'Upgrade "chart-operator" failed: no ClusterRole with the name "chart-operator-psp"`. The rbac rules for PSPs are a bit confused as they exist in both `psp.yaml` and `rbac.yaml` and duplicate each other.

Removing the extra role and binding aligns the chart with the resources already present in 8.2.0:

```
$ kg clusterrole,clusterrolebinding | grep chart-operator
clusterrole.rbac.authorization.k8s.io/chart-operator
clusterrole.rbac.authorization.k8s.io/chart-operator-psp-user 

clusterrolebinding.rbac.authorization.k8s.io/chart-operator
clusterrolebinding.rbac.authorization.k8s.io/chart-operator-psp
```