### PR TITLE
Add priorityclass template

### DIFF
--- a/helm/chart-operator/templates/priorityclass.yaml
+++ b/helm/chart-operator/templates/priorityclass.yaml
@@ -1,0 +1,8 @@
+{{ if .Values.e2e }}
+apiVersion: scheduling.k8s.io/v1beta1
+description: This priority class is used by giantswarm kubernetes components.
+kind: PriorityClass
+metadata:
+  name: giantswarm-critical
+value: 1000000000
+{{- end -}}


### PR DESCRIPTION
Needed for e2e in https://github.com/giantswarm/app-operator/pull/142.

This was added to chart-operator-chart but not chart-operator and it blocks chart-operator starting in e2e. In tenant clusters the giantswarm-critical priority class is created by ignition.

