### PR TITLE
Don't update chart-operator chart CR in case of failure

### DIFF
--- a/service/controller/chart/v1/resource/release/create_test.go
+++ b/service/controller/chart/v1/resource/release/create_test.go
@@ -75,6 +75,8 @@ func Test_Resource_Release_newCreate(t *testing.T) {
 			HelmClient: helmclienttest.New(helmclienttest.Config{}),
 			K8sClient:  k8sfake.NewSimpleClientset(),
 			Logger:     microloggertest.New(),
+
+			ProjectName: "chart-operator",
 		}
 
 		newResource, err = New(c)

--- a/service/controller/chart/v1/resource/release/current.go
+++ b/service/controller/chart/v1/resource/release/current.go
@@ -36,7 +36,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	if releaseContent.Status == "FAILED" && releaseContent.Name == r.projectName {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not updating release %#q since it's bootstrap from app-operator", releaseContent.Name))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not updating own release %#q since it's %#q", releaseContent.Name, releaseContent.Status))
 
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/chart/v1/resource/release/current.go
+++ b/service/controller/chart/v1/resource/release/current.go
@@ -35,7 +35,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	if releaseContent.Status == "FAILED" && releaseContent.Name == "chart-operator" {
+	if releaseContent.Status == "FAILED" && releaseContent.Name == r.projectName {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not updating release %#q since it's bootstrap from app-operator", releaseContent.Name))
 
 		resourcecanceledcontext.SetCanceled(ctx)

--- a/service/controller/chart/v1/resource/release/current.go
+++ b/service/controller/chart/v1/resource/release/current.go
@@ -35,6 +35,15 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
+	if releaseContent.Status == "FAILED" && releaseContent.Name == "chart-operator" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not updating release %#q since it's bootstrap from app-operator", releaseContent.Name))
+
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil, nil
+	}
+
 	releaseHistory, err := r.helmClient.GetReleaseHistory(ctx, releaseName)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/service/controller/chart/v1/resource/release/current_test.go
+++ b/service/controller/chart/v1/resource/release/current_test.go
@@ -147,6 +147,8 @@ func Test_CurrentState(t *testing.T) {
 				HelmClient: helmClient,
 				K8sClient:  k8sfake.NewSimpleClientset(),
 				Logger:     microloggertest.New(),
+
+				ProjectName: "chart-operator",
 			}
 
 			r, err := New(c)

--- a/service/controller/chart/v1/resource/release/delete_test.go
+++ b/service/controller/chart/v1/resource/release/delete_test.go
@@ -77,6 +77,8 @@ func Test_Resource_Release_newDeleteChange(t *testing.T) {
 			HelmClient: helmclienttest.New(helmclienttest.Config{}),
 			K8sClient:  k8sfake.NewSimpleClientset(),
 			Logger:     microloggertest.New(),
+
+			ProjectName: "chart-operator",
 		}
 
 		newResource, err = New(c)

--- a/service/controller/chart/v1/resource/release/desired_test.go
+++ b/service/controller/chart/v1/resource/release/desired_test.go
@@ -332,6 +332,8 @@ func Test_DesiredState(t *testing.T) {
 				HelmClient: helmClient,
 				K8sClient:  k8sfake.NewSimpleClientset(objs...),
 				Logger:     microloggertest.New(),
+
+				ProjectName: "chart-operator",
 			}
 			r, err := New(c)
 			if err != nil {

--- a/service/controller/chart/v1/resource/release/resource.go
+++ b/service/controller/chart/v1/resource/release/resource.go
@@ -49,6 +49,9 @@ type Config struct {
 	HelmClient helmclient.Interface
 	K8sClient  kubernetes.Interface
 	Logger     micrologger.Logger
+
+	// Settings.
+	ProjectName string
 }
 
 // Resource implements the chart resource.
@@ -59,6 +62,9 @@ type Resource struct {
 	helmClient helmclient.Interface
 	k8sClient  kubernetes.Interface
 	logger     micrologger.Logger
+
+	// Settings.
+	projectName string
 }
 
 // New creates a new configured chart resource.
@@ -80,6 +86,11 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	// Settings.
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
 	r := &Resource{
 		// Dependencies.
 		fs:         config.Fs,
@@ -87,6 +98,9 @@ func New(config Config) (*Resource, error) {
 		helmClient: config.HelmClient,
 		k8sClient:  config.K8sClient,
 		logger:     config.Logger,
+
+		// Settings.
+		projectName: config.ProjectName,
 	}
 
 	return r, nil

--- a/service/controller/chart/v1/resource/release/update_test.go
+++ b/service/controller/chart/v1/resource/release/update_test.go
@@ -152,6 +152,8 @@ func Test_Resource_Release_newUpdateChange(t *testing.T) {
 			HelmClient: helmclienttest.New(helmclienttest.Config{}),
 			K8sClient:  k8sfake.NewSimpleClientset(),
 			Logger:     microloggertest.New(),
+
+			ProjectName: "chart-operator",
 		}
 
 		newResource, err = New(c)

--- a/service/controller/chart/v1/resource_set.go
+++ b/service/controller/chart/v1/resource_set.go
@@ -64,11 +64,15 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var releaseResource resource.Interface
 	{
 		c := release.Config{
+			// Dependencies
 			Fs:         config.Fs,
 			G8sClient:  config.G8sClient,
 			HelmClient: config.HelmClient,
 			K8sClient:  config.K8sClient,
 			Logger:     config.Logger,
+
+			// Settings.
+			ProjectName: config.ProjectName,
 		}
 
 		ops, err := release.New(c)


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/7095

Canceling a release resource in case of it's chart-operator release since it would re-installed by app-operator. 