### PR TITLE
Add missing get verb for upgrading the tiller service

### DIFF
--- a/helm/chart-operator-chart/templates/rbac.yaml
+++ b/helm/chart-operator-chart/templates/rbac.yaml
@@ -95,6 +95,7 @@ rules:
   - serviceaccounts
   verbs:
   - "create"
+  - "get"
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/helm/chart-operator/templates/rbac.yaml
+++ b/helm/chart-operator/templates/rbac.yaml
@@ -95,6 +95,7 @@ rules:
   - serviceaccounts
   verbs:
   - "create"
+  - "get"
 - apiGroups:
   - networking.k8s.io
   resources:


### PR DESCRIPTION
Fixes a problem found testing the tiller upgrade.

The tiller installer that does the upgrade checks if the tiller service exists. But the cluster role only has the `create` role so this adds `get`.


https://github.com/helm/helm/blob/v2.14.3/cmd/helm/installer/install.go#L78-L83