### PR TITLE
Bump release channe to 0-11-stable

### DIFF
--- a/helm/chart-operator-chart/Chart.yaml
+++ b/helm/chart-operator-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the chart-operator
 name: chart-operator-chart
-version: 0.10.0
+version: 0.11.0


### PR DESCRIPTION
We now use the `0-10-stable` channel for all tenant clusters still using appr. So this bumps the release channel as a precaution.

For tenant clusters on 8.5.0 onwards we pull the chart from the default app catalog and we don't have this issue.