### PR TITLE
Backporting error handling in chartconfig

### DIFF
--- a/service/controller/chartconfig/v5/resource/chart/create.go
+++ b/service/controller/chartconfig/v5/resource/chart/create.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"k8s.io/helm/pkg/helm"
 
 	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v5/key"
@@ -54,6 +55,18 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		//
 		err = r.helmClient.InstallReleaseFromTarball(ctx, tarballPath, ns, helm.ReleaseName(chartState.ReleaseName), helm.ValueOverrides(values))
 		if err != nil {
+			releaseContent, err := r.helmClient.GetReleaseContent(ctx, chartState.ReleaseName)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			if releaseContent.Status == releaseStatusFailed {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to update release %#q", releaseContent.Name))
+
+				resourcecanceledcontext.SetCanceled(ctx)
+				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+				return nil
+			}
 			return microerror.Mask(err)
 		}
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart %s", chartState.ChartName))

--- a/service/controller/chartconfig/v5/resource/chart/resource.go
+++ b/service/controller/chartconfig/v5/resource/chart/resource.go
@@ -16,6 +16,7 @@ const (
 	Name = "chartv5"
 
 	releaseStatusDeployed = "DEPLOYED"
+	releaseStatusFailed   = "FAILED"
 )
 
 var (

--- a/service/controller/chartconfig/v6/resource/chart/resource.go
+++ b/service/controller/chartconfig/v6/resource/chart/resource.go
@@ -16,6 +16,7 @@ const (
 	Name = "chartv6"
 
 	releaseStatusDeployed = "DEPLOYED"
+	releaseStatusFailed   = "FAILED"
 )
 
 var (

--- a/service/controller/chartconfig/v6/resource/chart/update.go
+++ b/service/controller/chartconfig/v6/resource/chart/update.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"k8s.io/helm/pkg/helm"
 
 	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v6/key"
@@ -55,6 +56,18 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			helm.UpdateValueOverrides(values),
 			helm.UpgradeForce(upgradeForce))
 		if err != nil {
+			releaseContent, err := r.helmClient.GetReleaseContent(ctx, chartState.ReleaseName)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			if releaseContent.Status == releaseStatusFailed {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to update release %#q", releaseContent.Name))
+
+				resourcecanceledcontext.SetCanceled(ctx)
+				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+				return nil
+			}
 			return microerror.Mask(err)
 		}
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart %s", chartState.ChartName))

--- a/service/controller/chartconfig/v7/resource/chart/create.go
+++ b/service/controller/chartconfig/v7/resource/chart/create.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"k8s.io/helm/pkg/helm"
 
 	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
@@ -55,6 +56,18 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		//
 		err = r.helmClient.InstallReleaseFromTarball(ctx, tarballPath, ns, helm.ReleaseName(chartState.ReleaseName), helm.ValueOverrides(values))
 		if err != nil {
+			releaseContent, err := r.helmClient.GetReleaseContent(ctx, chartState.ReleaseName)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			if releaseContent.Status == releaseStatusFailed {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to update release %#q", releaseContent.Name))
+
+				resourcecanceledcontext.SetCanceled(ctx)
+				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+				return nil
+			}
 			return microerror.Mask(err)
 		}
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart %#q", chartState.ChartName))

--- a/service/controller/chartconfig/v7/resource/chart/resource.go
+++ b/service/controller/chartconfig/v7/resource/chart/resource.go
@@ -16,6 +16,7 @@ const (
 	Name = "chartv7"
 
 	releaseStatusDeployed = "DEPLOYED"
+	releaseStatusFailed   = "FAILED"
 )
 
 var (

--- a/service/controller/chartconfig/v7/resource/chart/update.go
+++ b/service/controller/chartconfig/v7/resource/chart/update.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"k8s.io/helm/pkg/helm"
 
 	"github.com/giantswarm/chart-operator/service/controller/chartconfig/v7/key"
@@ -55,6 +56,18 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			helm.UpdateValueOverrides(values),
 			helm.UpgradeForce(upgradeForce))
 		if err != nil {
+			releaseContent, err := r.helmClient.GetReleaseContent(ctx, chartState.ReleaseName)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			if releaseContent.Status == releaseStatusFailed {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to update release %#q", releaseContent.Name))
+
+				resourcecanceledcontext.SetCanceled(ctx)
+				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+				return nil
+			}
 			return microerror.Mask(err)
 		}
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart %#q", chartState.ChartName))


### PR DESCRIPTION
Backporting error handling into other `chartconfig` versionbundles so the operator could update `chartconfig` CR's status. 