### PR TITLE
No need to update releases when it's deleted.

### DIFF
--- a/service/controller/chart/v1/resource/release/update.go
+++ b/service/controller/chart/v1/resource/release/update.go
@@ -17,6 +17,12 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	if err != nil {
 		return microerror.Mask(err)
 	}
+	if key.IsDeleted(cr) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q would be deleted, no need to update it", key.ReleaseName(cr)))
+
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+	}
 	releaseState, err := toReleaseState(updateChange)
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
In some cases, the `update` event came after `delete` event so it creates a release that had been deleted again.

By this PR, the operator would cancel the resource if it's deleted.  

```
2019-10-25T11:10:30.440412089Z stdout F {"caller":"github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:274","controller":"chart-operator-chart","event":"delete","level":"debug","loop":"4","message":"reconciled object","object":"/apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/kubernetes-test-app-chart","time":"2019-10-25T11:10:30.440337+00:00","version":"974"}
2019-10-25T11:10:30.440542135Z stdout F {"caller":"github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:295","controller":"chart-operator-chart","event":"update","level":"debug","loop":"5","message":"reconciling object","object":"/apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/kubernetes-test-app-chart","time":"2019-10-25T11:10:30.440484+00:00","version":"967"}
```