### PR TITLE
Remove usage of e2e-harness framework package in e2e tests

### DIFF
--- a/integration/chartconfig/chartconfig.go
+++ b/integration/chartconfig/chartconfig.go
@@ -6,18 +6,13 @@ import (
 	"bytes"
 	"context"
 	"html/template"
-	"log"
-	"os"
-	"strings"
 
 	"github.com/giantswarm/apprclient"
-	"github.com/giantswarm/e2e-harness/pkg/framework"
 	"github.com/giantswarm/e2etemplates/pkg/e2etemplates"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
 	"k8s.io/helm/pkg/helm"
 
-	"github.com/giantswarm/chart-operator/integration/env"
 	"github.com/giantswarm/chart-operator/integration/setup"
 )
 
@@ -52,37 +47,6 @@ func InstallResources(ctx context.Context, config setup.Config) error {
 	}
 
 	return nil
-}
-
-func VersionBundleVersion(githubToken, testedVersion string) (string, error) {
-	if githubToken == "" {
-		return "", microerror.Maskf(failedExecutionError, "env var %#q must not be empty", env.EnvVarGithubBotToken)
-	}
-	if testedVersion == "" {
-		return "", microerror.Maskf(failedExecutionError, "env var %#q must not be empty", env.EnvVarTestedVersion)
-	}
-
-	params := &framework.VBVParams{
-		Component: "chart-operator",
-		Provider:  "aws",
-		Token:     githubToken,
-		VType:     testedVersion,
-	}
-	versionBundleVersion, err := framework.GetVersionBundleVersion(params)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	if versionBundleVersion == "" {
-		if strings.ToLower(testedVersion) == "wip" {
-			log.Println("WIP version bundle version not present, exiting.")
-			os.Exit(0)
-		}
-
-		return "", microerror.Maskf(failedExecutionError, "version bundle version must not be empty")
-	}
-
-	return versionBundleVersion, nil
 }
 
 func initializeCNR(ctx context.Context, config setup.Config) error {

--- a/integration/env/common.go
+++ b/integration/env/common.go
@@ -1,8 +1,12 @@
+// +build k8srequired
+
 package env
 
 import (
 	"fmt"
 	"os"
+
+	"github.com/giantswarm/chart-operator/service"
 )
 
 const (
@@ -21,14 +25,18 @@ const (
 	// EnvVarTestedVersion is the process environment variable representing the
 	// E2E_TESTED_VERSION env var.
 	EnvVarTestedVersion = "E2E_TESTED_VERSION"
+	// EnvVarVersionBundleVersion is the process environment variable representing the
+	// E2E_VERSION_BUNDLE_VERSION env var.
+	EnvVarVersionBundleVersion = "VERSION_BUNDLE_VERSION"
 )
 
 var (
-	circleCI      string
-	circleSHA     string
-	githubToken   string
-	keepResources string
-	testedVersion string
+	circleCI             string
+	circleSHA            string
+	githubToken          string
+	keepResources        string
+	testedVersion        string
+	versionBundleVersion string
 )
 
 func init() {
@@ -43,6 +51,18 @@ func init() {
 	// Optional environment variables only needed for chartconfig tests.
 	githubToken = os.Getenv(EnvVarGithubBotToken)
 	testedVersion = os.Getenv(EnvVarTestedVersion)
+
+	{
+		switch testedVersion {
+		case "latest", "wip":
+			vbs := service.NewVersionBundles()
+			versionBundleVersion = vbs[len(vbs)-1].Version
+		case "previous", "current":
+			vbs := service.NewVersionBundles()
+			versionBundleVersion = vbs[len(vbs)-2].Version
+		}
+	}
+	os.Setenv(EnvVarVersionBundleVersion, VersionBundleVersion())
 }
 
 func CircleCI() string {
@@ -63,4 +83,8 @@ func KeepResources() string {
 
 func TestedVersion() string {
 	return testedVersion
+}
+
+func VersionBundleVersion() string {
+	return versionBundleVersion
 }

--- a/integration/test/chartconfig/basic/basic_test.go
+++ b/integration/test/chartconfig/basic/basic_test.go
@@ -50,11 +50,6 @@ func TestChartLifecycle(t *testing.T) {
 		}
 	}
 
-	versionBundleVersion, err := chartconfig.VersionBundleVersion(env.GithubToken(), env.TestedVersion())
-	if err != nil {
-		t.Fatalf("could not get version bundle version %v", err)
-	}
-
 	// Test Creation
 	var chartConfigValues e2etemplates.ApiextensionsChartConfigValues
 	{
@@ -63,7 +58,7 @@ func TestChartLifecycle(t *testing.T) {
 			Name:                 "tb-chart",
 			Namespace:            "giantswarm",
 			Release:              "tb-release",
-			VersionBundleVersion: versionBundleVersion,
+			VersionBundleVersion: env.VersionBundleVersion(),
 		}
 
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating %#q", cr))

--- a/integration/test/chartconfig/chartvalues/chartvalues_test.go
+++ b/integration/test/chartconfig/chartvalues/chartvalues_test.go
@@ -33,17 +33,12 @@ func TestChartValues(t *testing.T) {
 		},
 	}
 
-	versionBundleVersion, err := chartconfig.VersionBundleVersion(env.GithubToken(), env.TestedVersion())
-	if err != nil {
-		t.Fatalf("could not get version bundle version %v", err)
-	}
-
 	chartConfigValues := e2etemplates.ApiextensionsChartConfigValues{
 		Channel:              "1-0-beta",
 		Name:                 "tb-chart",
 		Namespace:            "giantswarm",
 		Release:              "tb-release",
-		VersionBundleVersion: versionBundleVersion,
+		VersionBundleVersion: env.VersionBundleVersion(),
 	}
 	err = cnr.Push(ctx, config.K8sClients, charts)
 	if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4606

Same change Mr @kopiczko  made in https://github.com/giantswarm/azure-operator/pull/583 to remove usage of the framework package.