### PR TITLE
Cancel resource if helm release does not exist

### DIFF
--- a/service/controller/chart/v1/resource/release/create.go
+++ b/service/controller/chart/v1/resource/release/create.go
@@ -53,7 +53,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		if err != nil {
 			releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
 			if helmclient.IsReleaseNotFound(err) {
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release not found %#q", releaseContent.Name))
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q not found", releaseContent.Name))
 				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 				resourcecanceledcontext.SetCanceled(ctx)
 				return nil

--- a/service/controller/chart/v1/resource/release/create.go
+++ b/service/controller/chart/v1/resource/release/create.go
@@ -52,15 +52,18 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		err = r.helmClient.InstallReleaseFromTarball(ctx, tarballPath, ns, helm.ReleaseName(releaseState.Name), helm.ValueOverrides(releaseState.ValuesYAML))
 		if err != nil {
 			releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
-			if err != nil {
+			if helmclient.IsReleaseNotFound(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release not found %#q", releaseContent.Name))
+				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+				resourcecanceledcontext.SetCanceled(ctx)
+				return nil
+			} else if err != nil {
 				return microerror.Mask(err)
 			}
 			if releaseContent.Status == helmFailedStatus {
 				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to update release %#q", releaseContent.Name))
-
-				resourcecanceledcontext.SetCanceled(ctx)
 				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-
+				resourcecanceledcontext.SetCanceled(ctx)
 				return nil
 			}
 			return microerror.Mask(err)

--- a/service/controller/chart/v1/resource/release/update.go
+++ b/service/controller/chart/v1/resource/release/update.go
@@ -56,7 +56,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		if err != nil {
 			releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
 			if helmclient.IsReleaseNotFound(err) {
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release not found %#q", releaseContent.Name))
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q not found", releaseContent.Name))
 				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 				resourcecanceledcontext.SetCanceled(ctx)
 				return nil

--- a/service/controller/chart/v1/resource/release/update.go
+++ b/service/controller/chart/v1/resource/release/update.go
@@ -55,15 +55,18 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			helm.UpgradeForce(upgradeForce))
 		if err != nil {
 			releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
-			if err != nil {
+			if helmclient.IsReleaseNotFound(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release not found %#q", releaseContent.Name))
+				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+				resourcecanceledcontext.SetCanceled(ctx)
+				return nil
+			} else if err != nil {
 				return microerror.Mask(err)
 			}
 			if releaseContent.Status == helmFailedStatus {
 				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to update release %#q", releaseContent.Name))
-
-				resourcecanceledcontext.SetCanceled(ctx)
 				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-
+				resourcecanceledcontext.SetCanceled(ctx)
 				return nil
 			}
 			return microerror.Mask(err)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7355

Fixes errors seen when investigating aws-operator not being deployed to ginger.