### PR TITLE
fix panic, when release not found

### DIFF
--- a/service/controller/chart/v1/resource/release/create.go
+++ b/service/controller/chart/v1/resource/release/create.go
@@ -51,7 +51,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		if err != nil {
 			releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
 			if helmclient.IsReleaseNotFound(err) {
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q not found", releaseContent.Name))
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q not found", releaseState.Name))
 				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 				resourcecanceledcontext.SetCanceled(ctx)
 				return nil

--- a/service/controller/chart/v1/resource/release/update.go
+++ b/service/controller/chart/v1/resource/release/update.go
@@ -54,7 +54,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		if err != nil {
 			releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
 			if helmclient.IsReleaseNotFound(err) {
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q not found", releaseContent.Name))
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q not found", releaseState.Name))
 				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 				resourcecanceledcontext.SetCanceled(ctx)
 				return nil


### PR DESCRIPTION
Today we saw a panic in chart-operator when trying to install a chart, see https://gigantic.slack.com/archives/CPT91TRUM/p1576680572412000

```
{"caller":"github.com/giantswarm/chart-operator/service/controller/chart/v1/resource/release/create.go:26","event":"update","function":"ApplyCreateChange","level":"debug","message":"creating release `diagnostic-operator-add-rbac`","object":"/apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/diagnostic-operator-add-rbac","resource":"releasev1","time":"2019-12-18T14:49:09.312082+00:00","version":"31744732"}
E1218 14:49:09.819496       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 582 [running]:
github.com/giantswarm/chart-operator/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x18ad140, 0x2e93fb0)
        /go/src/github.com/giantswarm/chart-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
github.com/giantswarm/chart-operator/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /go/src/github.com/giantswarm/chart-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x18ad140, 0x2e93fb0)
        /usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/giantswarm/chart-operator/service/controller/chart/v1/resource/release.(*Resource).ApplyCreateChange(0xc0007fbdb0, 0x1dad0c0, 0xc000621860, 0x1aafdc0, 0xc00086c000, 0x179c760, 0xc00007e720, 0x0, 0x0)
        /go/src/github.com/giantswarm/chart-operator/service/controller/chart/v1/resource/release/create.go:54 +0x929
github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource.(*crudResource).ApplyCreateChange.func1(0xc0008efde0, 0xc000e90b00)
```
full log: [chart-operator-debug.log](https://github.com/giantswarm/chart-operator/files/3979049/chart-operator-debug.log)
)

