### PR TITLE
Improve chart CR status when chart tarballs cannot be pulled

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -272,7 +272,7 @@
   revision = "4dd4911251929a0ac4c4f3d8c4bda482a9e09f30"
 
 [[projects]]
-  branch = "master"
+  branch = "pull-chart-fixes"
   digest = "1:e83800c0f3c424b5232ff2900d93d8ef0ce47615f780c19561f8aef4273cbad5"
   name = "github.com/giantswarm/e2e-harness"
   packages = [
@@ -280,7 +280,7 @@
     "pkg/release",
   ]
   pruneopts = "UT"
-  revision = "b2048d8645c15ac583a270c57b95855426e48958"
+  revision = "b854963cbc9880c99460e661cbc7f95422f06e3d"
 
 [[projects]]
   branch = "master"
@@ -319,15 +319,15 @@
   revision = "9749deade60f7624620aa7158a4f38c87ea23795"
 
 [[projects]]
-  branch = "master"
-  digest = "1:04800286af6404ba25666bc07576c0b95b95cf8853a0985eaca0fae4f61076d2"
+  branch = "pull-chart-fixes"
+  digest = "1:2cbd28731c9f8a7e081f52f6940767c9cfbcf9920e6eb0b65ebef1131570c560"
   name = "github.com/giantswarm/helmclient"
   packages = [
     ".",
     "helmclienttest",
   ]
   pruneopts = "UT"
-  revision = "d1325340c4534d015b8e5abdae581883b030ec41"
+  revision = "474c46cff71f66ea0c293f19d22a1b38e7dcd74c"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -327,7 +327,7 @@
     "helmclienttest",
   ]
   pruneopts = "UT"
-  revision = "474c46cff71f66ea0c293f19d22a1b38e7dcd74c"
+  revision = "a4199ffd94b4499937d03de16d592d2503e65f0c"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -272,7 +272,7 @@
   revision = "4dd4911251929a0ac4c4f3d8c4bda482a9e09f30"
 
 [[projects]]
-  branch = "pull-chart-fixes"
+  branch = "master"
   digest = "1:e83800c0f3c424b5232ff2900d93d8ef0ce47615f780c19561f8aef4273cbad5"
   name = "github.com/giantswarm/e2e-harness"
   packages = [
@@ -280,7 +280,7 @@
     "pkg/release",
   ]
   pruneopts = "UT"
-  revision = "b854963cbc9880c99460e661cbc7f95422f06e3d"
+  revision = "b2048d8645c15ac583a270c57b95855426e48958"
 
 [[projects]]
   branch = "master"
@@ -319,7 +319,7 @@
   revision = "9749deade60f7624620aa7158a4f38c87ea23795"
 
 [[projects]]
-  branch = "pull-chart-fixes"
+  branch = "master"
   digest = "1:2cbd28731c9f8a7e081f52f6940767c9cfbcf9920e6eb0b65ebef1131570c560"
   name = "github.com/giantswarm/helmclient"
   packages = [
@@ -327,7 +327,7 @@
     "helmclienttest",
   ]
   pruneopts = "UT"
-  revision = "a4199ffd94b4499937d03de16d592d2503e65f0c"
+  revision = "31c66e94c95fa83f8f239acb865d63985e272873"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@ required = [
   name = "github.com/giantswarm/apprclient"
 
 [[constraint]]
-  branch = "pull-chart-fixes"
+  branch = "master"
   name = "github.com/giantswarm/e2e-harness"
 
 [[constraint]]
@@ -65,7 +65,7 @@ required = [
   name = "github.com/giantswarm/e2etemplates"
 
 [[constraint]]
-  branch = "pull-chart-fixes"
+  branch = "master"
   name = "github.com/giantswarm/helmclient"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@ required = [
   name = "github.com/giantswarm/apprclient"
 
 [[constraint]]
-  branch = "master"
+  branch = "pull-chart-fixes"
   name = "github.com/giantswarm/e2e-harness"
 
 [[constraint]]
@@ -65,7 +65,7 @@ required = [
   name = "github.com/giantswarm/e2etemplates"
 
 [[constraint]]
-  branch = "master"
+  branch = "pull-chart-fixes"
   name = "github.com/giantswarm/helmclient"
 
 [[constraint]]
@@ -118,10 +118,6 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  version = "kubernetes-1.16.3"
-
-[[constraint]]
-  name = "k8s.io/apiextensions-apiserver"
   version = "kubernetes-1.16.3"
 
 [[constraint]]

--- a/service/controller/chart/v1/controllercontext/context.go
+++ b/service/controller/chart/v1/controllercontext/context.go
@@ -1,0 +1,37 @@
+package controllercontext
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+type contextKey string
+
+const controllerKey contextKey = "controller"
+
+type Context struct {
+	Status Status
+}
+
+type Status struct {
+	Reason  string
+	Release Release
+}
+
+type Release struct {
+	Status string
+}
+
+func NewContext(ctx context.Context, c Context) context.Context {
+	return context.WithValue(ctx, controllerKey, &c)
+}
+
+func FromContext(ctx context.Context) (*Context, error) {
+	c, ok := ctx.Value(controllerKey).(*Context)
+	if !ok {
+		return nil, microerror.Maskf(notFoundError, "context key %q of type %T", controllerKey, controllerKey)
+	}
+
+	return c, nil
+}

--- a/service/controller/chart/v1/controllercontext/error.go
+++ b/service/controller/chart/v1/controllercontext/error.go
@@ -1,0 +1,14 @@
+package controllercontext
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/chart/v1/resource/release/desired.go
+++ b/service/controller/chart/v1/resource/release/desired.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/chart-operator/service/controller/chart/v1/controllercontext"
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/key"
 )
 
@@ -21,17 +22,45 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 
 	releaseName := key.ReleaseName(cr)
-
 	tarballURL := key.TarballURL(cr)
 
 	tarballPath, err := r.helmClient.PullChartTarball(ctx, tarballURL)
 	if helmclient.IsPullChartFailedError(err) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", "pulling chart failed", "stack", microerror.Stack(err))
+		// Add the status to the controller context. It will be used to set the
+		// CR status in the status resource.
+		cc.Status = controllercontext.Status{
+			Reason: fmt.Sprintf("Pulling chart %#q failed", tarballURL),
+			Release: controllercontext.Release{
+				Status: "Not installed",
+			},
+		}
+
+		r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("pulling chart %#q failed", tarballURL), "stack", microerror.Stack(err))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		resourcecanceledcontext.SetCanceled(ctx)
 		return nil, nil
+
+	} else if helmclient.IsPullChartNotFound(err) {
+		// Add the status to the controller context. It will be used to set the
+		// CR status in the status resource.
+		cc.Status = controllercontext.Status{
+			Reason: fmt.Sprintf("Chart %#q not found", tarballURL),
+			Release: controllercontext.Release{
+				Status: "Not installed",
+			},
+		}
+
+		r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("chart %#q not found", tarballURL), "stack", microerror.Stack(err))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/chart/v1/resource/release/desired_test.go
+++ b/service/controller/chart/v1/resource/release/desired_test.go
@@ -16,6 +16,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/chart-operator/service/controller/chart/v1/controllercontext"
 )
 
 func Test_DesiredState(t *testing.T) {
@@ -318,6 +320,12 @@ func Test_DesiredState(t *testing.T) {
 				objs = append(objs, tc.secret)
 			}
 
+			var ctx context.Context
+			{
+				c := controllercontext.Context{}
+				ctx = controllercontext.NewContext(context.Background(), c)
+			}
+
 			var helmClient helmclient.Interface
 			{
 				c := helmclienttest.Config{
@@ -338,7 +346,7 @@ func Test_DesiredState(t *testing.T) {
 				t.Fatalf("error == %#v, want nil", err)
 			}
 
-			result, err := r.GetDesiredState(context.TODO(), tc.obj)
+			result, err := r.GetDesiredState(ctx, tc.obj)
 			switch {
 			case err != nil && tc.errorMatcher == nil:
 				t.Fatalf("error == %#v, want nil", err)

--- a/service/controller/chart/v1/resource/status/create.go
+++ b/service/controller/chart/v1/resource/status/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/chart-operator/service/controller/chart/v1/controllercontext"
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/key"
 )
 
@@ -16,6 +17,28 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	cr, err := key.ToCustomResource(obj)
 	if err != nil {
 		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// If a reason was added to the controller context something went wrong.
+	// So we set the CR status and return early.
+	if cc.Status.Reason != "" {
+		status := v1alpha1.ChartStatus{
+			Reason: cc.Status.Reason,
+			Release: v1alpha1.ChartStatusRelease{
+				Status: cc.Status.Release.Status,
+			},
+		}
+
+		err = r.setStatus(ctx, cr, status)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		return nil
 	}
 
 	releaseName := key.ReleaseName(cr)
@@ -66,25 +89,34 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if !equals(desiredStatus, key.ChartStatus(cr)) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting status for release %#q status to %#q", releaseName, releaseContent.Status))
-
-		// Get chart CR again to ensure the resource version is correct.
-		currentCR, err := r.g8sClient.ApplicationV1alpha1().Charts(cr.Namespace).Get(cr.Name, metav1.GetOptions{})
+		err = r.setStatus(ctx, cr, desiredStatus)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		currentCR.Status = desiredStatus
-
-		_, err = r.g8sClient.ApplicationV1alpha1().Charts(cr.Namespace).UpdateStatus(currentCR)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("set status for release %#q", releaseName))
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("status for release %#q already set to %#q", releaseName, releaseContent.Status))
 	}
+
+	return nil
+}
+
+func (r *Resource) setStatus(ctx context.Context, cr v1alpha1.Chart, status v1alpha1.ChartStatus) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting status for release %#q status to %#q", key.ReleaseName(cr), status.Release.Status))
+
+	// Get chart CR again to ensure the resource version is correct.
+	currentCR, err := r.g8sClient.ApplicationV1alpha1().Charts(cr.Namespace).Get(cr.Name, metav1.GetOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	currentCR.Status = status
+
+	_, err = r.g8sClient.ApplicationV1alpha1().Charts(cr.Namespace).UpdateStatus(currentCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("set status for release %#q", key.ReleaseName(cr)))
 
 	return nil
 }

--- a/service/controller/chart/v1/resource_set.go
+++ b/service/controller/chart/v1/resource_set.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/afero"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/giantswarm/chart-operator/service/controller/chart/v1/controllercontext"
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/key"
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/resource/release"
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/resource/status"
@@ -131,6 +132,9 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	}
 
 	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		cc := controllercontext.Context{}
+		ctx = controllercontext.NewContext(ctx, cc)
+
 		return ctx, nil
 	}
 

--- a/vendor/github.com/giantswarm/helmclient/error.go
+++ b/vendor/github.com/giantswarm/helmclient/error.go
@@ -95,6 +95,15 @@ func IsPullChartFailedError(err error) bool {
 	return microerror.Cause(err) == pullChartFailedError
 }
 
+var pullChartNotFoundError = &microerror.Error{
+	Kind: "pullChartNotFoundError",
+}
+
+// IsPullChartNotFound asserts pullChartNotFoundError.
+func IsPullChartNotFound(err error) bool {
+	return microerror.Cause(err) == pullChartNotFoundError
+}
+
 var (
 	releaseAlreadyExistsRegexp = regexp.MustCompile(`release named \S+ already exists`)
 )


### PR DESCRIPTION
Currently we add info about errors from helm to the chart CR status. But there is no info about errors pulling the chart tarball.

This adds a controller context for passing this info from the `release` resource to the `status` resource. The chart CR status is then propagated to the app CR status. Eventually I think we should shows this in the UI.

Needs https://github.com/giantswarm/helmclient/pull/143 first.