### PR TITLE
Grant chart-operator missing permissions

### DIFF
--- a/helm/chart-operator-chart/templates/rbac.yaml
+++ b/helm/chart-operator-chart/templates/rbac.yaml
@@ -88,6 +88,7 @@ rules:
   - clusterroles
   verbs:
   - "bind"
+  - "create"
 - apiGroups:
   - ""
   resources:

--- a/helm/chart-operator-chart/templates/rbac.yaml
+++ b/helm/chart-operator-chart/templates/rbac.yaml
@@ -119,6 +119,13 @@ rules:
   - "create"
   - "get"
   - "update"
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - "create"
+  - "use"
 - nonResourceURLs:
   - "/"
   - "/healthz"


### PR DESCRIPTION
Once `atlantis` installation was unfrozen (`draughstman` scaled up again), `tiller` did not get upgraded from 2.14.3 to 2.16.1. After some investigation found out that rights are missing for chart-operator ClusterRole, preventing tiller installation/upgrade.

Root cause is we have two chart-operator charts, and they get out of sync, it's too easy to make mistake - make change in just one of the two charts.

Slack threads:
- unfreezing of atlantis yesterday: https://gigantic.slack.com/archives/C02EVLE9W/p1576674594034400
- uncovering of this RBAC issue while investigating AppNotInstalled batman alert notification https://gigantic.slack.com/archives/C03CPNRTS/p1576751368003400