### PR TITLE
Add orphan configmap metric

### DIFF
--- a/helm/chart-operator-chart/templates/rbac.yaml
+++ b/helm/chart-operator-chart/templates/rbac.yaml
@@ -70,6 +70,7 @@ rules:
   - secrets
   verbs:
   - "get"
+  - "list"
 - apiGroups:
   - ""
   resources:

--- a/helm/chart-operator/templates/rbac.yaml
+++ b/helm/chart-operator/templates/rbac.yaml
@@ -70,6 +70,7 @@ rules:
   - secrets
   verbs:
   - "get"
+  - "list"
 - apiGroups:
   - ""
   resources:

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -1,0 +1,8 @@
+// Package label contains common Kubernetes object labels. These are defined in
+// https://github.com/giantswarm/fmt/blob/master/kubernetes/annotations_and_labels.md.
+package label
+
+const (
+	// ManagedBy is set for Kubernetes resources managed by the operator.
+	ManagedBy = "giantswarm.io/managed-by"
+)

--- a/service/collector/chart_config_resource.go
+++ b/service/collector/chart_config_resource.go
@@ -105,7 +105,7 @@ func (c *ChartConfigResource) Collect(ch chan<- prometheus.Metric) error {
 		)
 	}
 
-	c.logger.Log("level", "debug", "message", "finished collecting metrics for ChartConfigs")
+	c.logger.Log("level", "debug", "message", "collected metrics for ChartConfigs")
 
 	return nil
 }

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -7,7 +7,6 @@ const (
 
 const (
 	labelChart         = "chart_name"
-	labelConfigMap     = "configmap_name"
 	labelChannel       = "channel_name"
 	labelRelease       = "release_name"
 	labelReleaseStatus = "release_status"

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -7,6 +7,7 @@ const (
 
 const (
 	labelChart         = "chart_name"
+	labelConfigMap     = "configmap_name"
 	labelChannel       = "channel_name"
 	labelRelease       = "release_name"
 	labelReleaseStatus = "release_status"

--- a/service/collector/orphan_configmap.go
+++ b/service/collector/orphan_configmap.go
@@ -97,7 +97,7 @@ func (oc *OrphanConfigMap) Collect(ch chan<- prometheus.Metric) error {
 	)
 
 	if len(orphanConfigMaps) > 0 {
-		oc.logger.Log("level", "debug", "message", "found %d orphan configmaps %s", len(orphanConfigMaps), strings.Join(orphanConfigMaps, " "))
+		oc.logger.Log("level", "debug", "message", fmt.Sprintf("found %d orphan configmaps %s", len(orphanConfigMaps), strings.Join(orphanConfigMaps, " ")))
 	}
 
 	oc.logger.Log("level", "debug", "message", "finished collecting metrics for orphan configmaps")

--- a/service/collector/orphan_configmap.go
+++ b/service/collector/orphan_configmap.go
@@ -100,7 +100,7 @@ func (oc *OrphanConfigMap) Collect(ch chan<- prometheus.Metric) error {
 		oc.logger.Log("level", "debug", "message", fmt.Sprintf("found %d orphan configmaps %s", len(orphanConfigMaps), strings.Join(orphanConfigMaps, " ")))
 	}
 
-	oc.logger.Log("level", "debug", "message", "finished collecting metrics for orphan configmaps")
+	oc.logger.Log("level", "debug", "message", "collected metrics for orphan configmaps")
 
 	return nil
 }

--- a/service/collector/orphan_configmap.go
+++ b/service/collector/orphan_configmap.go
@@ -64,11 +64,10 @@ func (oc *OrphanConfigMap) Collect(ch chan<- prometheus.Metric) error {
 		return microerror.Mask(err)
 	}
 
-	desiredConfigMaps := make(map[string]bool)
+	desiredConfigMaps := make(map[[2]string]bool)
 
-	for _, cr := range charts.Items {
-		key := fmt.Sprintf("%s.%s", key.ConfigMapNamespace(cr), key.ConfigMapName(cr))
-		desiredConfigMaps[key] = true
+	for _, chart := range charts.Items {
+		desiredConfigMaps[[2]string{key.ConfigMapNamespace(chart), key.ConfigMapName(chart)}] = true
 	}
 
 	lo := metav1.ListOptions{
@@ -82,11 +81,8 @@ func (oc *OrphanConfigMap) Collect(ch chan<- prometheus.Metric) error {
 	var orphanConfigMaps []string
 
 	for _, cm := range configMaps.Items {
-		key := fmt.Sprintf("%s.%s", cm.Namespace, cm.Name)
-
-		exists, _ := desiredConfigMaps[key]
-		if !exists {
-			orphanConfigMaps = append(orphanConfigMaps, key)
+		if !desiredConfigMaps[[2]string{cm.Namespace, cm.Name}] {
+			orphanConfigMaps = append(orphanConfigMaps, fmt.Sprintf("%s.%s", cm.Namespace, cm.Name))
 		}
 	}
 

--- a/service/collector/orphan_configmap.go
+++ b/service/collector/orphan_configmap.go
@@ -49,6 +49,7 @@ func NewOrphanConfigMap(config OrphanConfigMapConfig) (*OrphanConfigMap, error) 
 
 	oc := &OrphanConfigMap{
 		g8sClient: config.G8sClient,
+		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 	}
 

--- a/service/collector/orphan_configmap.go
+++ b/service/collector/orphan_configmap.go
@@ -1,0 +1,111 @@
+package collector
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/chart-operator/pkg/label"
+	"github.com/giantswarm/chart-operator/service/controller/chart/v1/key"
+)
+
+var (
+	orphanConfigMapDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "configmap", "orphan"),
+		"Configmaps without a chart CR.",
+		[]string{},
+		nil,
+	)
+)
+
+type OrphanConfigMapConfig struct {
+	G8sClient versioned.Interface
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+type OrphanConfigMap struct {
+	g8sClient versioned.Interface
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+func NewOrphanConfigMap(config OrphanConfigMapConfig) (*OrphanConfigMap, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	oc := &OrphanConfigMap{
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return oc, nil
+}
+
+func (oc *OrphanConfigMap) Collect(ch chan<- prometheus.Metric) error {
+	oc.logger.Log("level", "debug", "message", "collecting metrics for orphan configmaps")
+
+	charts, err := oc.g8sClient.ApplicationV1alpha1().Charts("").List(metav1.ListOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	desiredConfigMaps := make(map[string]bool)
+
+	for _, cr := range charts.Items {
+		key := fmt.Sprintf("%s.%s", key.ConfigMapNamespace(cr), key.ConfigMapName(cr))
+		desiredConfigMaps[key] = true
+	}
+
+	lo := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, "app-operator"),
+	}
+	configMaps, err := oc.k8sClient.CoreV1().ConfigMaps("").List(lo)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var orphanConfigMaps []string
+
+	for _, cm := range configMaps.Items {
+		key := fmt.Sprintf("%s.%s", cm.Namespace, cm.Name)
+
+		exists, _ := desiredConfigMaps[key]
+		if !exists {
+			orphanConfigMaps = append(orphanConfigMaps, key)
+		}
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		orphanConfigMapDesc,
+		prometheus.GaugeValue,
+		float64(len(orphanConfigMaps)),
+	)
+
+	if len(orphanConfigMaps) > 0 {
+		oc.logger.Log("level", "debug", "message", "found %d orphan configmaps %s", len(orphanConfigMaps), strings.Join(orphanConfigMaps, " "))
+	}
+
+	oc.logger.Log("level", "debug", "message", "finished collecting metrics for orphan configmaps")
+
+	return nil
+}
+
+// Describe emits the description for the metrics collected here.
+func (oc *OrphanConfigMap) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- orphanConfigMapDesc
+	return nil
+}

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -53,6 +53,20 @@ func NewSet(config SetConfig) (*Set, error) {
 		}
 	}
 
+	var orphanConfigMapCollector *OrphanConfigMap
+	{
+		c := OrphanConfigMapConfig{
+			G8sClient: config.K8sClient.G8sClient(),
+			K8sClient: config.K8sClient.K8sClient(),
+			Logger:    config.Logger,
+		}
+
+		orphanConfigMapCollector, err = NewOrphanConfigMap(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var tillerMaxHistoryCollector *TillerMaxHistory
 	{
 		c := TillerMaxHistoryConfig{
@@ -106,6 +120,7 @@ func NewSet(config SetConfig) (*Set, error) {
 		c := collector.SetConfig{
 			Collectors: []collector.Interface{
 				chartConfigResourceCollector,
+				orphanConfigMapCollector,
 				tillerMaxHistoryCollector,
 				tillerReachableCollector,
 				tillerRunningPodsCollector,

--- a/service/collector/tiller_max_history.go
+++ b/service/collector/tiller_max_history.go
@@ -107,7 +107,7 @@ func (t *TillerMaxHistory) Collect(ch chan<- prometheus.Metric) error {
 		t.tillerNamespace,
 	)
 
-	t.logger.Log("level", "debug", "message", "finished collecting Tiller max history")
+	t.logger.Log("level", "debug", "message", "collected Tiller max history")
 
 	return nil
 }

--- a/service/collector/tiller_reachable.go
+++ b/service/collector/tiller_reachable.go
@@ -110,7 +110,7 @@ func (t *TillerReachable) Collect(ch chan<- prometheus.Metric) error {
 		t.tillerNamespace,
 	)
 
-	t.logger.Log("level", "debug", "message", "finished collecting Tiller reachability")
+	t.logger.Log("level", "debug", "message", "collected Tiller reachability")
 
 	return nil
 }

--- a/service/collector/tiller_running_pods.go
+++ b/service/collector/tiller_running_pods.go
@@ -110,7 +110,7 @@ func (t *TillerRunningPods) Collect(ch chan<- prometheus.Metric) error {
 		t.tillerNamespace,
 	)
 
-	t.logger.Log("level", "debug", "message", "finished collecting Tiller running pods")
+	t.logger.Log("level", "debug", "message", "collected Tiller running pods")
 
 	return nil
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8187

Adds metric for orphan configmaps without a chart CR. Not implemented in app-operator because then it would need to access tenant clusters.