### PR TITLE
Log stack traces when helm release is failed

### DIFF
--- a/service/controller/chart/v1/resource/release/create.go
+++ b/service/controller/chart/v1/resource/release/create.go
@@ -55,7 +55,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		// use the default values and prevent errors on nested values.
 		err = r.helmClient.InstallReleaseFromTarball(ctx, tarballPath, ns, helm.ReleaseName(releaseState.Name), helm.ValueOverrides(releaseState.ValuesYAML))
 		if err != nil {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "helm release %#q failed", "stack", microerror.Stack(err))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q failed", releaseState.Name), "stack", microerror.Stack(err))
 
 			releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
 			if helmclient.IsReleaseNotFound(err) {

--- a/service/controller/chart/v1/resource/release/create.go
+++ b/service/controller/chart/v1/resource/release/create.go
@@ -55,7 +55,8 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		// use the default values and prevent errors on nested values.
 		err = r.helmClient.InstallReleaseFromTarball(ctx, tarballPath, ns, helm.ReleaseName(releaseState.Name), helm.ValueOverrides(releaseState.ValuesYAML))
 		if err != nil {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "r.helmClient.InstallReleaseFromTarball failed", "stack", microerror.Stack(err))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "helm release %#q failed", "stack", microerror.Stack(err))
+
 			releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
 			if helmclient.IsReleaseNotFound(err) {
 				// Add the status to the controller context. It will be used to set the

--- a/service/controller/chart/v1/resource/release/update.go
+++ b/service/controller/chart/v1/resource/release/update.go
@@ -58,6 +58,8 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			helm.UpdateValueOverrides(releaseState.ValuesYAML),
 			helm.UpgradeForce(upgradeForce))
 		if err != nil {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "helm release %#q failed", "stack", microerror.Stack(err))
+
 			releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
 			if helmclient.IsReleaseNotFound(err) {
 				// Add the status to the controller context. It will be used to set the

--- a/service/controller/chart/v1/resource/release/update.go
+++ b/service/controller/chart/v1/resource/release/update.go
@@ -58,7 +58,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			helm.UpdateValueOverrides(releaseState.ValuesYAML),
 			helm.UpgradeForce(upgradeForce))
 		if err != nil {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "helm release %#q failed", "stack", microerror.Stack(err))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q failed", releaseState.Name), "stack", microerror.Stack(err))
 
 			releaseContent, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
 			if helmclient.IsReleaseNotFound(err) {


### PR DESCRIPTION
@oponder improved the logging during Operator Week. ❤️ A couple of small changes to extend that.