### PR TITLE
Improve error handling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -272,7 +272,7 @@
   revision = "4dd4911251929a0ac4c4f3d8c4bda482a9e09f30"
 
 [[projects]]
-  branch = "errors"
+  branch = "master"
   digest = "1:e83800c0f3c424b5232ff2900d93d8ef0ce47615f780c19561f8aef4273cbad5"
   name = "github.com/giantswarm/e2e-harness"
   packages = [
@@ -280,7 +280,7 @@
     "pkg/release",
   ]
   pruneopts = "UT"
-  revision = "5499c764f3903c03c1d81ebc27d8daec97c893aa"
+  revision = "b2048d8645c15ac583a270c57b95855426e48958"
 
 [[projects]]
   branch = "master"
@@ -319,7 +319,7 @@
   revision = "9749deade60f7624620aa7158a4f38c87ea23795"
 
 [[projects]]
-  branch = "errors"
+  branch = "master"
   digest = "1:59666dd6a2cb373e09b7c6e49e71f305e8063587ba87f11822bc841ebd07a83c"
   name = "github.com/giantswarm/helmclient"
   packages = [
@@ -327,7 +327,7 @@
     "helmclienttest",
   ]
   pruneopts = "UT"
-  revision = "1d1b325d97650f5ea5b7266b1cc3d37d2213691e"
+  revision = "fb9810df314da5cbbad9ee1187428868aaa47e30"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -272,7 +272,7 @@
   revision = "4dd4911251929a0ac4c4f3d8c4bda482a9e09f30"
 
 [[projects]]
-  branch = "master"
+  branch = "errors"
   digest = "1:e83800c0f3c424b5232ff2900d93d8ef0ce47615f780c19561f8aef4273cbad5"
   name = "github.com/giantswarm/e2e-harness"
   packages = [
@@ -280,7 +280,7 @@
     "pkg/release",
   ]
   pruneopts = "UT"
-  revision = "b2048d8645c15ac583a270c57b95855426e48958"
+  revision = "5499c764f3903c03c1d81ebc27d8daec97c893aa"
 
 [[projects]]
   branch = "master"
@@ -319,15 +319,15 @@
   revision = "9749deade60f7624620aa7158a4f38c87ea23795"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2423542e01e5bae49a8c33a5f1b0d78dbc8aff780726bc4d9eb8552ae535f5fa"
+  branch = "errors"
+  digest = "1:59666dd6a2cb373e09b7c6e49e71f305e8063587ba87f11822bc841ebd07a83c"
   name = "github.com/giantswarm/helmclient"
   packages = [
     ".",
     "helmclienttest",
   ]
   pruneopts = "UT"
-  revision = "e64c820cdb5d608d81cac7f866d6347467481c71"
+  revision = "1d1b325d97650f5ea5b7266b1cc3d37d2213691e"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@ required = [
   name = "github.com/giantswarm/apprclient"
 
 [[constraint]]
-  branch = "master"
+  branch = "errors"
   name = "github.com/giantswarm/e2e-harness"
 
 [[constraint]]
@@ -65,7 +65,7 @@ required = [
   name = "github.com/giantswarm/e2etemplates"
 
 [[constraint]]
-  branch = "master"
+  branch = "errors"
   name = "github.com/giantswarm/helmclient"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@ required = [
   name = "github.com/giantswarm/apprclient"
 
 [[constraint]]
-  branch = "errors"
+  branch = "master"
   name = "github.com/giantswarm/e2e-harness"
 
 [[constraint]]
@@ -65,7 +65,7 @@ required = [
   name = "github.com/giantswarm/e2etemplates"
 
 [[constraint]]
-  branch = "errors"
+  branch = "master"
   name = "github.com/giantswarm/helmclient"
 
 [[constraint]]

--- a/service/controller/chart/v1/resource/release/create.go
+++ b/service/controller/chart/v1/resource/release/create.go
@@ -76,9 +76,10 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			} else if err != nil {
 				return microerror.Mask(err)
 			}
+
 			// Release is failed so the status resource will check the Helm release.
 			if releaseContent.Status == helmFailedStatus {
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to update release %#q", releaseContent.Name))
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to create release %#q", releaseContent.Name))
 				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 				resourcecanceledcontext.SetCanceled(ctx)
 				return nil

--- a/service/controller/chart/v1/resource/release/current_test.go
+++ b/service/controller/chart/v1/resource/release/current_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/chart-operator/service/controller/chart/v1/controllercontext"
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/helmclient/helmclienttest"
 	"github.com/giantswarm/micrologger/microloggertest"
@@ -131,6 +132,12 @@ func Test_CurrentState(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var ctx context.Context
+			{
+				c := controllercontext.Context{}
+				ctx = controllercontext.NewContext(context.Background(), c)
+			}
+
 			var helmClient helmclient.Interface
 			{
 				c := helmclienttest.Config{
@@ -154,7 +161,7 @@ func Test_CurrentState(t *testing.T) {
 				t.Fatalf("error == %#v, want nil", err)
 			}
 
-			result, err := r.GetCurrentState(context.TODO(), tc.obj)
+			result, err := r.GetCurrentState(ctx, tc.obj)
 			switch {
 			case err != nil && !tc.expectedError:
 				t.Fatalf("error == %#v, want nil", err)

--- a/service/service.go
+++ b/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"sync"
+	"time"
 
 	applicationv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
@@ -124,10 +125,11 @@ func New(config Config) (*Service, error) {
 			K8sClient: k8sClient.K8sClient(),
 			Logger:    config.Logger,
 
-			RestConfig:           restConfig,
-			TillerImageRegistry:  config.Viper.GetString(config.Flag.Service.Image.Registry),
-			TillerNamespace:      config.Viper.GetString(config.Flag.Service.Helm.TillerNamespace),
-			TillerUpgradeEnabled: true,
+			EnsureTillerInstalledMaxWait: 30 * time.Second,
+			RestConfig:                   restConfig,
+			TillerImageRegistry:          config.Viper.GetString(config.Flag.Service.Image.Registry),
+			TillerNamespace:              config.Viper.GetString(config.Flag.Service.Helm.TillerNamespace),
+			TillerUpgradeEnabled:         true,
 		}
 
 		helmClient, err = helmclient.New(c)

--- a/vendor/github.com/giantswarm/helmclient/ensure_tiller_installed.go
+++ b/vendor/github.com/giantswarm/helmclient/ensure_tiller_installed.go
@@ -498,7 +498,7 @@ func (c *Client) installTiller(ctx context.Context, installerOptions *installer.
 
 		return nil
 	}
-	b := backoff.NewExponential(2*time.Minute, 5*time.Second)
+	b := backoff.NewExponential(c.ensureTillerInstalledMaxWait, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, context.Background())
 
 	err := backoff.RetryNotify(o, b, n)
@@ -522,7 +522,7 @@ func (c *Client) upgradeTiller(ctx context.Context, installerOptions *installer.
 
 		return nil
 	}
-	b := backoff.NewExponential(2*time.Minute, 5*time.Second)
+	b := backoff.NewExponential(c.ensureTillerInstalledMaxWait, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, context.Background())
 
 	err := backoff.RetryNotify(o, b, n)

--- a/vendor/github.com/giantswarm/helmclient/error.go
+++ b/vendor/github.com/giantswarm/helmclient/error.go
@@ -33,6 +33,32 @@ func IsCannotReuseRelease(err error) bool {
 	return false
 }
 
+var (
+	emptyChartTemplatesRegexp = regexp.MustCompile(`release \S+ failed: no objects visited`)
+)
+
+var emptyChartTemplatesError = &microerror.Error{
+	Kind: "emptyChartTemplatesError",
+}
+
+// IsEmptyChartTemplates asserts emptyChartTemplatesError.
+func IsEmptyChartTemplates(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == emptyChartTemplatesError {
+		return true
+	}
+	if emptyChartTemplatesRegexp.MatchString(c.Error()) {
+		return true
+	}
+
+	return false
+}
+
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
 }
@@ -124,6 +150,62 @@ func IsReleaseAlreadyExists(err error) bool {
 		return true
 	}
 	if releaseAlreadyExistsRegexp.MatchString(c.Error()) {
+		return true
+	}
+
+	return false
+}
+
+const (
+	releaseNameInvalidErrorPrefix = "invalid release name"
+	releaseNameInvalidErrorSuffix = "and the length must not be longer than 53"
+)
+
+var releaseNameInvalidError = &microerror.Error{
+	Kind: "releaseNameInvalidError",
+}
+
+// IsReleaseNameInvalid asserts releaseNameInvalidError.
+func IsReleaseNameInvalid(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if strings.HasPrefix(c.Error(), releaseNameInvalidErrorPrefix) {
+		return true
+	}
+	if strings.HasSuffix(c.Error(), releaseNameInvalidErrorSuffix) {
+		return true
+	}
+	if c == releaseNameInvalidError {
+		return true
+	}
+
+	return false
+}
+
+const (
+	releaseNotDeployedErrorSuffix = "has no deployed releases"
+)
+
+var releaseNotDeployedError = &microerror.Error{
+	Kind: "releaseNotDeployedError",
+}
+
+// IsReleaseNotDeployed asserts releaseNotDeployedError.
+func IsReleaseNotDeployed(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if strings.HasSuffix(c.Error(), releaseNotDeployedErrorSuffix) {
+		return true
+	}
+	if c == releaseNotDeployedError {
 		return true
 	}
 

--- a/vendor/github.com/giantswarm/helmclient/helmclient.go
+++ b/vendor/github.com/giantswarm/helmclient/helmclient.go
@@ -201,6 +201,10 @@ func (c *Client) getReleaseContent(ctx context.Context, releaseName string) (*Re
 			t, err := c.newTunnel()
 			if IsTillerNotFound(err) {
 				return backoff.Permanent(microerror.Mask(err))
+			} else if IsEmptyChartTemplates(err) {
+				return backoff.Permanent(microerror.Mask(err))
+			} else if IsReleaseNameInvalid(err) {
+				return backoff.Permanent(microerror.Mask(err))
 			} else if err != nil {
 				return microerror.Mask(err)
 			}
@@ -347,6 +351,8 @@ func (c *Client) installReleaseFromTarball(ctx context.Context, path, ns string,
 		if IsCannotReuseRelease(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsReleaseAlreadyExists(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsEmptyChartTemplates(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsTarballNotFound(err) {
 			return backoff.Permanent(microerror.Mask(err))
@@ -600,7 +606,11 @@ func (c *Client) updateReleaseFromTarball(ctx context.Context, releaseName, path
 		defer c.closeTunnel(ctx, t)
 
 		release, err := c.newHelmClientFromTunnel(t).UpdateRelease(releaseName, path, options...)
-		if IsReleaseNotFound(err) {
+		if IsReleaseNotDeployed(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsReleaseNotFound(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsEmptyChartTemplates(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsYamlConversionFailed(err) {
 			return backoff.Permanent(microerror.Mask(err))


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7355

Needs https://github.com/giantswarm/helmclient/pull/147 first. Improves error handling to cover.

- Chart tarball has an empty templates directory.
- Helm release name is invalid.
- Helm release is not deployed.
