### PR TITLE
Remove noisy collector logs

### DIFF
--- a/service/collector/chart_config_resource.go
+++ b/service/collector/chart_config_resource.go
@@ -68,8 +68,6 @@ func NewChartConfigResource(config ChartConfigResourceConfig) (*ChartConfigResou
 }
 
 func (c *ChartConfigResource) Collect(ch chan<- prometheus.Metric) error {
-	c.logger.Log("level", "debug", "message", "collecting metrics for ChartConfigs")
-
 	chartConfigs, err := c.g8sClient.CoreV1alpha1().ChartConfigs("").List(metav1.ListOptions{})
 	if err != nil {
 		return microerror.Mask(err)
@@ -104,8 +102,6 @@ func (c *ChartConfigResource) Collect(ch chan<- prometheus.Metric) error {
 			key.ChartName(chartConfig),
 		)
 	}
-
-	c.logger.Log("level", "debug", "message", "collected metrics for ChartConfigs")
 
 	return nil
 }

--- a/service/collector/tiller_max_history.go
+++ b/service/collector/tiller_max_history.go
@@ -74,8 +74,6 @@ func NewTillerMaxHistory(config TillerMaxHistoryConfig) (*TillerMaxHistory, erro
 func (t *TillerMaxHistory) Collect(ch chan<- prometheus.Metric) error {
 	var value float64
 
-	t.logger.Log("level", "debug", "message", "collecting Tiller max history")
-
 	charts, err := t.g8sClient.ApplicationV1alpha1().Charts("").List(metav1.ListOptions{})
 	if err != nil {
 		return microerror.Mask(err)
@@ -106,8 +104,6 @@ func (t *TillerMaxHistory) Collect(ch chan<- prometheus.Metric) error {
 		value,
 		t.tillerNamespace,
 	)
-
-	t.logger.Log("level", "debug", "message", "collected Tiller max history")
 
 	return nil
 }

--- a/service/collector/tiller_reachable.go
+++ b/service/collector/tiller_reachable.go
@@ -73,8 +73,6 @@ func (t *TillerReachable) Collect(ch chan<- prometheus.Metric) error {
 
 	ctx := context.Background()
 
-	t.logger.Log("level", "debug", "message", "collecting Tiller reachability")
-
 	charts, err := t.g8sClient.ApplicationV1alpha1().Charts("").List(metav1.ListOptions{})
 	if err != nil {
 		return microerror.Mask(err)
@@ -109,8 +107,6 @@ func (t *TillerReachable) Collect(ch chan<- prometheus.Metric) error {
 		value,
 		t.tillerNamespace,
 	)
-
-	t.logger.Log("level", "debug", "message", "collected Tiller reachability")
 
 	return nil
 }

--- a/service/collector/tiller_running_pods.go
+++ b/service/collector/tiller_running_pods.go
@@ -73,8 +73,6 @@ func (t *TillerRunningPods) Collect(ch chan<- prometheus.Metric) error {
 
 	ctx := context.Background()
 
-	t.logger.Log("level", "debug", "message", "collecting Tiller running pods")
-
 	charts, err := t.g8sClient.ApplicationV1alpha1().Charts("").List(metav1.ListOptions{})
 	if err != nil {
 		return microerror.Mask(err)
@@ -109,8 +107,6 @@ func (t *TillerRunningPods) Collect(ch chan<- prometheus.Metric) error {
 		value,
 		t.tillerNamespace,
 	)
-
-	t.logger.Log("level", "debug", "message", "collected Tiller running pods")
 
 	return nil
 }


### PR DESCRIPTION
See https://github.com/giantswarm/chart-operator/pull/344/files#r366212863.

I can't remember why but we have extra logging in the collector here. This makes the logs noisy so removing it. 