### PR TITLE
Fix clusterrole to include priority class

### DIFF
--- a/helm/chart-operator-chart/templates/rbac.yaml
+++ b/helm/chart-operator-chart/templates/rbac.yaml
@@ -105,9 +105,9 @@ rules:
   verbs:
   - create
 - apiGroups:
-  - networking.k8s.io
+  - scheduling.k8s.io
   resources:
-  - networkpolicies
+  - priorityclass
   verbs:
   - create
 - apiGroups:


### PR DESCRIPTION
Tiller has not been upgraded in `gorilla` because the cluster role in the chart used by draughtsman was wrong.