### PR TITLE
 Make priorityclasses plural in cluster roles

### DIFF
--- a/helm/chart-operator-chart/templates/rbac.yaml
+++ b/helm/chart-operator-chart/templates/rbac.yaml
@@ -107,8 +107,8 @@ rules:
 - apiGroups:
   - scheduling.k8s.io
   resources:
-  - priorityclass
-  verbs:
+  - priorityclasses
+  verb:
   - create
 - apiGroups:
   - apps

--- a/helm/chart-operator-chart/templates/rbac.yaml
+++ b/helm/chart-operator-chart/templates/rbac.yaml
@@ -108,7 +108,7 @@ rules:
   - scheduling.k8s.io
   resources:
   - priorityclasses
-  verb:
+  verbs:
   - create
 - apiGroups:
   - apps

--- a/helm/chart-operator/templates/rbac.yaml
+++ b/helm/chart-operator/templates/rbac.yaml
@@ -107,7 +107,7 @@ rules:
 - apiGroups:
   - scheduling.k8s.io
   resources:
-  - priorityclass
+  - priorityclasses
   verbs:
   - create
 - apiGroups:


### PR DESCRIPTION
We had some problems earlier with tiller being downgraded and then chart-operator couldn't upgrade it.

I managed to get the rbac wrong in both charts. 🤦‍♂ 