### PR TITLE
Skip pulling chart in case of chart CR deletion

### DIFF
--- a/service/controller/chart/v1/resource/release/desired.go
+++ b/service/controller/chart/v1/resource/release/desired.go
@@ -31,7 +31,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	tarballURL := key.TarballURL(cr)
 
 	if key.IsDeleted(cr) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "CR deletion only, skipping pulling a helm chart")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting chart. skip pulling chart tarball")
 		releaseState := &ReleaseState{
 			Name:   releaseName,
 			Status: helmDeployedStatus,

--- a/service/controller/chart/v1/resource/release/desired.go
+++ b/service/controller/chart/v1/resource/release/desired.go
@@ -30,6 +30,15 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	releaseName := key.ReleaseName(cr)
 	tarballURL := key.TarballURL(cr)
 
+	if key.IsDeleted(cr) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "CR deletion only, skipping pulling a helm chart")
+		releaseState := &ReleaseState{
+			Name:   releaseName,
+			Status: helmDeployedStatus,
+		}
+		return releaseState, nil
+	}
+
 	tarballPath, err := r.helmClient.PullChartTarball(ctx, tarballURL)
 	if helmclient.IsPullChartFailedError(err) {
 		reason := fmt.Sprintf("pulling chart %#q failed", tarballURL)


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/9064
We are pulling charts in deletion events but this is useless since we only need to delete helm release. 