### PR TITLE
Use client-go in basic integration test

### DIFF
--- a/integration/key/release_name.go
+++ b/integration/key/release_name.go
@@ -8,10 +8,6 @@ func ChartConfigReleaseName() string {
 	return "apiextensions-chart-config-e2e-chart"
 }
 
-func ChartReleaseName() string {
-	return "apiextensions-chart-e2e-chart"
-}
-
 func TestAppReleaseName() string {
 	return "test-app"
 }

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -30,11 +30,11 @@ func TestChartLifecycle(t *testing.T) {
 
 	// Test creation.
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart %#q", key.TestAppReleaseName()))
 
-		cr := v1alpha1.Chart{
+		cr := &v1alpha1.Chart{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "1.0.0",
+				Name:      key.TestAppReleaseName(),
 				Namespace: "giantswarm",
 				Labels: map[string]string{
 					"chart-operator.giantswarm.io/version": "1.0.0",
@@ -47,12 +47,12 @@ func TestChartLifecycle(t *testing.T) {
 				Version:    "0.7.0",
 			},
 		}
-		_, err := setup.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(cr)
+		_, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(cr)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart %#q", key.TestAppReleaseName()))
 
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking release %#q is deployed", key.TestAppReleaseName()))
 
@@ -112,7 +112,7 @@ func TestChartLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chart %#q", key.TestAppReleaseName()))
 
-		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
+		err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -16,13 +16,13 @@ import (
 // TestChartLifecycle tests a Helm release can be created, updated and deleted
 // uaing a chart CR processed by chart-operator.
 //
-// - Create chart CR using apiextensions-chart-e2e-chart.
-// - Ensure test app specfied in the chart CR is deployed.
+// - Create chart CR.
+// - Ensure test app specified in the chart CR is deployed.
 //
-// - Update chart CR using apiextensions-chart-e2e-chart.
+// - Update chart CR.
 // - Ensure test app is redeployed using updated chart tarball.
 //
-// - Delete apiextensions-chart-e2e-chart.
+// - Delete chart CR.
 // - Ensure test app is deleted.
 //
 func TestChartLifecycle(t *testing.T) {

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -41,7 +41,7 @@ func TestChartLifecycle(t *testing.T) {
 				},
 			},
 			Spec: v1alpha1.ChartSpec{
-				Name:       "1.0.0",
+				Name:       key.TestAppReleaseName(),
 				Namespace:  "giantswarm",
 				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz",
 			},

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -44,7 +44,6 @@ func TestChartLifecycle(t *testing.T) {
 				Name:       "1.0.0",
 				Namespace:  "giantswarm",
 				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz",
-				Version:    "0.7.0",
 			},
 		}
 		_, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(cr)
@@ -89,7 +88,6 @@ func TestChartLifecycle(t *testing.T) {
 		}
 
 		cr.Spec.TarballURL = "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.1.tgz"
-		cr.Spec.Version = "0.7.1"
 
 		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Update(cr)
 		if err != nil {

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -7,8 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/giantswarm/e2e-harness/pkg/release"
-	"github.com/giantswarm/e2etemplates/pkg/chartvalues"
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/chart-operator/integration/key"
@@ -33,30 +32,22 @@ func TestChartLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart %#q", key.ChartReleaseName()))
 
-		c := chartvalues.APIExtensionsChartE2EConfig{
-			Chart: chartvalues.APIExtensionsChartE2EConfigChart{
-				Name:       key.TestAppReleaseName(),
+		cr := v1alpha1.Chart{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "1.0.0",
+				Namespace: "giantswarm",
+				Labels: map[string]string{
+					"chart-operator.giantswarm.io/version": "1.0.0",
+				},
+			},
+			Spec: v1alpha1.ChartSpec{
+				Name:       "1.0.0",
 				Namespace:  "giantswarm",
 				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz",
+				Version:    "0.7.0",
 			},
-			ChartOperator: chartvalues.APIExtensionsChartE2EConfigChartOperator{
-				Version: "1.0.0",
-			},
-			Namespace: "giantswarm",
 		}
-
-		chartValues, err := chartvalues.NewAPIExtensionsChartE2E(c)
-		if err != nil {
-			t.Fatalf("expected %#v got %#v", nil, err)
-		}
-
-		chartInfo := release.NewStableChartInfo(key.ChartReleaseName())
-		err = config.Release.Install(ctx, key.ChartReleaseName(), chartInfo, chartValues)
-		if err != nil {
-			t.Fatalf("expected %#v got %#v", nil, err)
-		}
-
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", "giantswarm", key.ChartReleaseName()), "DEPLOYED")
+		_, err := setup.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(cr)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -90,38 +81,22 @@ func TestChartLifecycle(t *testing.T) {
 
 	// Test update.
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart %#q", key.TestAppReleaseName()))
 
-		c := chartvalues.APIExtensionsChartE2EConfig{
-			Chart: chartvalues.APIExtensionsChartE2EConfigChart{
-				Name:      key.TestAppReleaseName(),
-				Namespace: "giantswarm",
-				// Newer version of the tarball is deployed.
-				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.1.tgz",
-			},
-			ChartOperator: chartvalues.APIExtensionsChartE2EConfigChartOperator{
-				Version: "1.0.0",
-			},
-			Namespace: "giantswarm",
-		}
-
-		updatedValues, err := chartvalues.NewAPIExtensionsChartE2E(c)
+		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		chartInfo := release.NewStableChartInfo(key.ChartReleaseName())
-		err = config.Release.Update(ctx, key.ChartReleaseName(), chartInfo, updatedValues)
+		cr.Spec.TarballURL = "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.1.tgz"
+		cr.Spec.Version = "0.7.1"
+
+		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Update(cr)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", "giantswarm", key.ChartReleaseName()), "DEPLOYED")
-		if err != nil {
-			t.Fatalf("expected %#v got %#v", nil, err)
-		}
-
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart %#q", key.TestAppReleaseName()))
 
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking release %#q is updated", key.TestAppReleaseName()))
 
@@ -135,19 +110,14 @@ func TestChartLifecycle(t *testing.T) {
 
 	// Test deletion.
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chart %#q", key.TestAppReleaseName()))
 
-		err := config.Release.Delete(ctx, key.ChartReleaseName())
+		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", "giantswarm", key.ChartReleaseName()), "DELETED")
-		if err != nil {
-			t.Fatalf("expected %#v got %#v", nil, err)
-		}
-
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted chart %#q", key.TestAppReleaseName()))
 
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking release %#q is deleted", key.TestAppReleaseName()))
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/30

This is prep for adding a new migration integration test. This is so the legacy chartconfig controller can be removed.

But first sorting out the basic integration test. It uses a helm chart in `apiextensions` to create a chart CR. This is overkill and adds a lot of complexity so now we just use `client-go`.