### PR TITLE
Add chartmigration resource for helm 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,52 +84,14 @@ jobs:
       E2E_TEST_DIR: "integration/test/chart/basic"
     <<: *e2eTest
 
-  e2eTestChartConfigCurBasicPR:
+  e2eTestChartMigrationPR:
     environment:
-      E2E_TEST_DIR: "integration/test/chartconfig/basic"
-      E2E_TESTED_VERSION: "current"
+      E2E_TEST_DIR: "integration/test/chart/migration"
     <<: *e2eTest
-
-  e2eTestChartConfigCurBasicMaster:
+  
+  e2eTestChartMigrationMaster:
     environment:
-      E2E_TEST_DIR: "integration/test/chartconfig/basic"
-      E2E_TESTED_VERSION: "current"
-    <<: *e2eTest
-
-  e2eTestChartConfigWIPBasicPR:
-    environment:
-      E2E_TEST_DIR: "integration/test/chartconfig/basic"
-      E2E_TESTED_VERSION: "wip"
-    <<: *e2eTest
-
-  e2eTestChartConfigWIPBasicMaster:
-    environment:
-      E2E_TEST_DIR: "integration/test/chartconfig/basic"
-      E2E_TESTED_VERSION: "wip"
-    <<: *e2eTest
-
-  e2eTestChartConfigCurChartValuesPR:
-    environment:
-      E2E_TEST_DIR: "integration/test/chartconfig/chartvalues"
-      E2E_TESTED_VERSION: "current"
-    <<: *e2eTest
-
-  e2eTestChartConfigCurChartValuesMaster:
-    environment:
-      E2E_TEST_DIR: "integration/test/chartconfig/chartvalues"
-      E2E_TESTED_VERSION: "current"
-    <<: *e2eTest
-
-  e2eTestChartConfigWIPChartValuesPR:
-    environment:
-      E2E_TEST_DIR: "integration/test/chartconfig/chartvalues"
-      E2E_TESTED_VERSION: "wip"
-    <<: *e2eTest
-
-  e2eTestChartConfigWIPChartValuesMaster:
-    environment:
-      E2E_TEST_DIR: "integration/test/chartconfig/chartvalues"
-      E2E_TESTED_VERSION: "wip"
+      E2E_TEST_DIR: "integration/test/chart/migration"
     <<: *e2eTest
 
   deploy:
@@ -222,44 +184,11 @@ workflows:
           requires:
           - build
 
-      - e2eTestChartConfigCurBasicPR:
+      - e2eTestChartMigrationPR:
           requires:
           - build
 
-      - e2eTestChartConfigCurBasicMaster:
-          filters:
-            branches:
-              only: master
-          requires:
-          - build
-
-      - e2eTestChartConfigWIPBasicPR:
-          requires:
-          - build
-
-      - e2eTestChartConfigWIPBasicMaster:
-          filters:
-            branches:
-              only: master
-          requires:
-          - build
-
-      - e2eTestChartConfigCurChartValuesPR:
-          requires:
-          - build
-
-      - e2eTestChartConfigCurChartValuesMaster:
-          filters:
-            branches:
-              only: master
-          requires:
-          - build
-
-      - e2eTestChartConfigWIPChartValuesPR:
-          requires:
-          - build
-
-      - e2eTestChartConfigWIPChartValuesMaster:
+      - e2eTestChartMigrationMaster:
           filters:
             branches:
               only: master
@@ -272,10 +201,7 @@ workflows:
               only: master
           requires:
           - e2eTestChartBasicMaster
-          - e2eTestChartConfigCurBasicMaster
-          - e2eTestChartConfigWIPBasicMaster
-          - e2eTestChartConfigCurChartValuesMaster
-          - e2eTestChartConfigWIPChartValuesMaster
+          - e2eTestChartMigrationMaster
           - push-chart-operator-to-aliyun-legacy
 
       - publish_to_stable:

--- a/integration/key/release_name.go
+++ b/integration/key/release_name.go
@@ -8,10 +8,6 @@ func ChartConfigReleaseName() string {
 	return "apiextensions-chart-config-e2e-chart"
 }
 
-func ChartReleaseName() string {
-	return "apiextensions-chart-e2e-chart"
-}
-
 func TestAppReleaseName() string {
 	return "test-app"
 }

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/e2e-harness/pkg/release"
 	"github.com/giantswarm/microerror"
 
@@ -54,7 +54,7 @@ func installResources(ctx context.Context, config Config) error {
 	}
 
 	{
-		err = config.Release.InstallOperator(ctx, key.ChartOperatorReleaseName(), release.NewVersion(env.CircleSHA()), templates.ChartOperatorValues, v1alpha1.NewChartConfigCRD())
+		err = config.Release.InstallOperator(ctx, key.ChartOperatorReleaseName(), release.NewVersion(env.CircleSHA()), templates.ChartOperatorValues, v1alpha1.NewChartCRD())
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -30,11 +30,11 @@ func TestChartLifecycle(t *testing.T) {
 
 	// Test creation.
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart %#q", key.TestAppReleaseName()))
 
-		cr := v1alpha1.Chart{
+		cr := &v1alpha1.Chart{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "1.0.0",
+				Name:      key.TestAppReleaseName(),
 				Namespace: "giantswarm",
 				Labels: map[string]string{
 					"chart-operator.giantswarm.io/version": "1.0.0",
@@ -47,12 +47,12 @@ func TestChartLifecycle(t *testing.T) {
 				Version:    "0.7.0",
 			},
 		}
-		_, err := setup.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(cr)
+		_, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(cr)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart %#q", key.TestAppReleaseName()))
 
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking release %#q is deployed", key.TestAppReleaseName()))
 
@@ -112,7 +112,7 @@ func TestChartLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chart %#q", key.TestAppReleaseName()))
 
-		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
+		err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -41,7 +41,7 @@ func TestChartLifecycle(t *testing.T) {
 				},
 			},
 			Spec: v1alpha1.ChartSpec{
-				Name:       "1.0.0",
+				Name:       key.TestAppReleaseName(),
 				Namespace:  "giantswarm",
 				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz",
 			},

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -44,7 +44,6 @@ func TestChartLifecycle(t *testing.T) {
 				Name:       "1.0.0",
 				Namespace:  "giantswarm",
 				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz",
-				Version:    "0.7.0",
 			},
 		}
 		_, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(cr)
@@ -89,7 +88,6 @@ func TestChartLifecycle(t *testing.T) {
 		}
 
 		cr.Spec.TarballURL = "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.1.tgz"
-		cr.Spec.Version = "0.7.1"
 
 		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Update(cr)
 		if err != nil {

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -7,8 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/giantswarm/e2e-harness/pkg/release"
-	"github.com/giantswarm/e2etemplates/pkg/chartvalues"
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/chart-operator/integration/key"
@@ -33,30 +32,22 @@ func TestChartLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart %#q", key.ChartReleaseName()))
 
-		c := chartvalues.APIExtensionsChartE2EConfig{
-			Chart: chartvalues.APIExtensionsChartE2EConfigChart{
-				Name:       key.TestAppReleaseName(),
+		cr := v1alpha1.Chart{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "1.0.0",
+				Namespace: "giantswarm",
+				Labels: map[string]string{
+					"chart-operator.giantswarm.io/version": "1.0.0",
+				},
+			},
+			Spec: v1alpha1.ChartSpec{
+				Name:       "1.0.0",
 				Namespace:  "giantswarm",
 				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz",
+				Version:    "0.7.0",
 			},
-			ChartOperator: chartvalues.APIExtensionsChartE2EConfigChartOperator{
-				Version: "1.0.0",
-			},
-			Namespace: "giantswarm",
 		}
-
-		chartValues, err := chartvalues.NewAPIExtensionsChartE2E(c)
-		if err != nil {
-			t.Fatalf("expected %#v got %#v", nil, err)
-		}
-
-		chartInfo := release.NewStableChartInfo(key.ChartReleaseName())
-		err = config.Release.Install(ctx, key.ChartReleaseName(), chartInfo, chartValues)
-		if err != nil {
-			t.Fatalf("expected %#v got %#v", nil, err)
-		}
-
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", "giantswarm", key.ChartReleaseName()), "DEPLOYED")
+		_, err := setup.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(cr)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -90,38 +81,22 @@ func TestChartLifecycle(t *testing.T) {
 
 	// Test update.
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart %#q", key.TestAppReleaseName()))
 
-		c := chartvalues.APIExtensionsChartE2EConfig{
-			Chart: chartvalues.APIExtensionsChartE2EConfigChart{
-				Name:      key.TestAppReleaseName(),
-				Namespace: "giantswarm",
-				// Newer version of the tarball is deployed.
-				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.1.tgz",
-			},
-			ChartOperator: chartvalues.APIExtensionsChartE2EConfigChartOperator{
-				Version: "1.0.0",
-			},
-			Namespace: "giantswarm",
-		}
-
-		updatedValues, err := chartvalues.NewAPIExtensionsChartE2E(c)
+		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		chartInfo := release.NewStableChartInfo(key.ChartReleaseName())
-		err = config.Release.Update(ctx, key.ChartReleaseName(), chartInfo, updatedValues)
+		cr.Spec.TarballURL = "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.1.tgz"
+		cr.Spec.Version = "0.7.1"
+
+		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Update(cr)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", "giantswarm", key.ChartReleaseName()), "DEPLOYED")
-		if err != nil {
-			t.Fatalf("expected %#v got %#v", nil, err)
-		}
-
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart %#q", key.TestAppReleaseName()))
 
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking release %#q is updated", key.TestAppReleaseName()))
 
@@ -135,19 +110,14 @@ func TestChartLifecycle(t *testing.T) {
 
 	// Test deletion.
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chart %#q", key.TestAppReleaseName()))
 
-		err := config.Release.Delete(ctx, key.ChartReleaseName())
+		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", "giantswarm", key.ChartReleaseName()), "DELETED")
-		if err != nil {
-			t.Fatalf("expected %#v got %#v", nil, err)
-		}
-
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted chart %#q", key.ChartReleaseName()))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted chart %#q", key.TestAppReleaseName()))
 
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking release %#q is deleted", key.TestAppReleaseName()))
 

--- a/integration/test/chart/migration/main_test.go
+++ b/integration/test/chart/migration/main_test.go
@@ -1,0 +1,30 @@
+// +build k8srequired
+
+package migration
+
+import (
+	"testing"
+
+	"github.com/giantswarm/chart-operator/integration/setup"
+)
+
+var (
+	config setup.Config
+)
+
+func init() {
+	var err error
+
+	{
+		config, err = setup.NewConfig()
+		if err != nil {
+			panic(err.Error())
+		}
+	}
+}
+
+// TestMain allows us to have common setup and teardown steps that are run
+// once for all the tests https://golang.org/pkg/testing/#hdr-Main.
+func TestMain(m *testing.M) {
+	setup.Setup(m, config)
+}

--- a/integration/test/chart/migration/migration_test.go
+++ b/integration/test/chart/migration/migration_test.go
@@ -130,7 +130,12 @@ func TestChartMigration(t *testing.T) {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		annotations := chartConfig.Annotations
+		annotations := []string{}
+
+		if chartConfig.Annotations != nil && len(chartConfig.Annotations) > 0 {
+			annotations = chartConfig.Annotations
+		}
+
 		annotations[annotation.DeleteCustomResourceOnly] = "true"
 		chartConfig.Annotations = annotations
 

--- a/integration/test/chart/migration/migration_test.go
+++ b/integration/test/chart/migration/migration_test.go
@@ -130,7 +130,7 @@ func TestChartMigration(t *testing.T) {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		annotations := []string{}
+		annotations := map[string]string{}
 
 		if chartConfig.Annotations != nil && len(chartConfig.Annotations) > 0 {
 			annotations = chartConfig.Annotations

--- a/integration/test/chart/migration/migration_test.go
+++ b/integration/test/chart/migration/migration_test.go
@@ -22,6 +22,7 @@ import (
 // TestChartMigration tests chartconfig CR is deleted once it has been migrated
 // to a chart CR.
 //
+// Create chartconfig CRD.
 // Create chartconfig CR.
 // Create chart CR.
 //
@@ -35,6 +36,18 @@ import (
 //
 func TestChartMigration(t *testing.T) {
 	ctx := context.Background()
+
+	// Create legacy chartconfig CRD.
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "creating chartconfig CRD")
+
+		err := config.K8sClients.CRDClient().EnsureCreated(ctx, corev1alpha1.NewChartConfigCRD(), backoff.NewMaxRetries(7, 1*time.Second))
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "created chartconfig CRD")
+	}
 
 	// Create legacy chartconfig CR.
 	{

--- a/integration/test/chart/migration/migration_test.go
+++ b/integration/test/chart/migration/migration_test.go
@@ -1,0 +1,184 @@
+// +build k8srequired
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/chart-operator/integration/key"
+	"github.com/giantswarm/chart-operator/pkg/annotation"
+)
+
+// TestChartMigration tests chartconfig CR is deleted once it has been migrated
+// to a chart CR.
+//
+// Create chartconfig CR.
+// Create chart CR.
+//
+// Ensure test-app is deployed.
+//
+// Add annotation to chartconfig CR to mark that migration is complete.
+// Delete chartconfig CR.
+//
+// Ensure that finalizer is removed and chartconfig CR is deleted.
+// Ensure test-app is still deployed.
+//
+func TestChartMigration(t *testing.T) {
+	ctx := context.Background()
+
+	// Create legacy chartconfig CR.
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chartconfig %#q", key.TestAppReleaseName()))
+
+		chartConfig := &corev1alpha1.ChartConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      key.TestAppReleaseName(),
+				Namespace: "giantswarm",
+				Finalizers: []string{
+					// Finalizer is created manually because there is no
+					// chartconfig controller.
+					"operatorkit.giantswarm.io/chart-operator-chartconfig",
+				},
+			},
+			Spec: corev1alpha1.ChartConfigSpec{
+				Chart: corev1alpha1.ChartConfigSpecChart{
+					Channel:   "test",
+					Name:      key.TestAppReleaseName(),
+					Namespace: "giantswarm",
+					Release:   key.TestAppReleaseName(),
+				},
+				VersionBundle: corev1alpha1.ChartConfigSpecVersionBundle{
+					Version: "0.7.0",
+				},
+			},
+		}
+		_, err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs("giantswarm").Create(chartConfig)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chartconfig %#q", key.TestAppReleaseName()))
+	}
+
+	// Create chart CR.
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart %#q", key.TestAppReleaseName()))
+
+		chart := &v1alpha1.Chart{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      key.TestAppReleaseName(),
+				Namespace: "giantswarm",
+				Labels: map[string]string{
+					"chart-operator.giantswarm.io/version": "1.0.0",
+				},
+			},
+			Spec: v1alpha1.ChartSpec{
+				Name:       "1.0.0",
+				Namespace:  "giantswarm",
+				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz",
+			},
+		}
+		_, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(chart)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart %#q", key.TestAppReleaseName()))
+	}
+
+	// Check test-app is deployed.
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking release %#q is deployed", key.TestAppReleaseName()))
+
+		err := config.Release.WaitForStatus(ctx, key.TestAppReleaseName(), "DEPLOYED")
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q is deployed", key.TestAppReleaseName()))
+	}
+
+	// Add annotation to chartconfig CR to mark that migration is complete.
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("adding annotation to chartconfig %#q", key.TestAppReleaseName()))
+
+		chartConfig, err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		annotations := chartConfig.Annotations
+		annotations[annotation.DeleteCustomResourceOnly] = "true"
+		chartConfig.Annotations = annotations
+
+		_, err = config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs("giantswarm").Update(chartConfig)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("added annotation to chartconfig %#q", key.TestAppReleaseName()))
+	}
+
+	// Delete chartconfig CR.
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chartconfig %#q", key.TestAppReleaseName()))
+
+		err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs("giantswarm").Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted chartconfig %#q", key.TestAppReleaseName()))
+	}
+
+	// Check chartconfig CR is deleted.
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking chartconfig %#q was deleted", key.TestAppReleaseName()))
+
+		o := func() error {
+			_, err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				// Error is expected because finalizer was removed.
+				return nil
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+
+			return nil
+		}
+
+		n := func(err error, t time.Duration) {
+			config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to get not found error: retrying in %s", t), "stack", fmt.Sprintf("%v", err))
+		}
+
+		b := backoff.NewExponential(backoff.MediumMaxWait, backoff.LongMaxInterval)
+		err := backoff.RetryNotify(o, b, n)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checked chartconfig %#q was deleted", key.TestAppReleaseName()))
+	}
+
+	// Check test-app is still deployed.
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking release %#q is deployed", key.TestAppReleaseName()))
+
+		err := config.Release.WaitForStatus(ctx, key.TestAppReleaseName(), "DEPLOYED")
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q is deployed", key.TestAppReleaseName()))
+	}
+}

--- a/integration/test/chart/migration/migration_test.go
+++ b/integration/test/chart/migration/migration_test.go
@@ -96,7 +96,7 @@ func TestChartMigration(t *testing.T) {
 				},
 			},
 			Spec: v1alpha1.ChartSpec{
-				Name:       "1.0.0",
+				Name:       key.TestAppReleaseName(),
 				Namespace:  "giantswarm",
 				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz",
 			},

--- a/service/controller/chart/v1/key/key.go
+++ b/service/controller/chart/v1/key/key.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/chart-operator/pkg/annotation"
@@ -51,6 +52,23 @@ func HasForceUpgradeAnnotation(customResource v1alpha1.Chart) bool {
 	if err != nil {
 		// If we cannot parse the boolean we return false and this is shown
 		// in the logs.
+		return false
+	}
+
+	return result
+}
+
+// HasDeleteCROnlyAnnotation returns true if the legacy chartconfig CR has the
+// delete custom resource only annotation added by cluster-operator to signal
+// that the migration to chart CR is complete.
+func HasDeleteCROnlyAnnotation(customResource *corev1alpha1.ChartConfig) bool {
+	val, ok := customResource.Annotations[annotation.DeleteCustomResourceOnly]
+	if !ok {
+		return false
+	}
+
+	result, err := strconv.ParseBool(val)
+	if err != nil {
 		return false
 	}
 

--- a/service/controller/chart/v1/resource/chartmigration/create.go
+++ b/service/controller/chart/v1/resource/chartmigration/create.go
@@ -1,0 +1,49 @@
+package chartmigration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/chart-operator/service/controller/chart/v1/key"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCustomResource(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding chartconfig %#q", cr.Name))
+
+	chartConfig, err := r.g8sClient.CoreV1alpha1().ChartConfigs(cr.Namespace).Get(cr.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find chartconfig %#q. nothing to do.", cr.Name))
+		return nil
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found chartconfig %#q", cr.Name))
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking if chartconfig %#q has been migrated", cr.Name))
+
+	if key.HasDeleteCROnlyAnnotation(chartConfig) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chartconfig %#q has been migrated", cr.Name))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "removing finalizers")
+
+		chartConfig.ObjectMeta.Finalizers = []string{}
+		_, err = r.g8sClient.CoreV1alpha1().ChartConfigs("giantswarm").Update(chartConfig)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "removed finalizers")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chartconfig %#q has not been migrated", cr.Name))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
+	return nil
+}

--- a/service/controller/chart/v1/resource/chartmigration/delete.go
+++ b/service/controller/chart/v1/resource/chartmigration/delete.go
@@ -1,0 +1,10 @@
+package chartmigration
+
+import (
+	"context"
+)
+
+// EnsureDeleted is not implemented as no migration is required.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/chart/v1/resource/chartmigration/error.go
+++ b/service/controller/chart/v1/resource/chartmigration/error.go
@@ -1,0 +1,14 @@
+package chartmigration
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/chart/v1/resource/chartmigration/resource.go
+++ b/service/controller/chart/v1/resource/chartmigration/resource.go
@@ -1,0 +1,44 @@
+package chartmigration
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "chartmigrationv1"
+)
+
+// Config represents the configuration used to create a new tiller resource.
+type Config struct {
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the tiller resource.
+type Resource struct {
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured tiller resource.
+func New(config Config) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/chart/v1/resource_set.go
+++ b/service/controller/chart/v1/resource_set.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/controllercontext"
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/key"
+	"github.com/giantswarm/chart-operator/service/controller/chart/v1/resource/chartmigration"
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/resource/release"
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/resource/status"
 	"github.com/giantswarm/chart-operator/service/controller/chart/v1/resource/tiller"
@@ -55,6 +56,19 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	var chartMigrationResource resource.Interface
+	{
+		c := chartmigration.Config{
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+		}
+
+		chartMigrationResource, err = chartmigration.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
 	}
 
 	var releaseResource resource.Interface
@@ -107,6 +121,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	}
 
 	resources := []resource.Interface{
+		chartMigrationResource,
 		tillerResource,
 		releaseResource,
 		statusResource,

--- a/service/controller/chartconfig/chart_config.go
+++ b/service/controller/chartconfig/chart_config.go
@@ -98,14 +98,13 @@ func NewChartConfig(config Config) (*ChartConfig, error) {
 	var chartConfigController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:          v1alpha1.NewChartConfigCRD(),
-			K8sClient:    config.K8sClient,
-			Logger:       config.Logger,
+			CRD:       v1alpha1.NewChartConfigCRD(),
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
 			ResourceSets: []*controller.ResourceSet{
-				// Just disable resource sets for now.
-				// resourceSetV5,
-				// resourceSetV6,
-				// resourceSetV7,
+				resourceSetV5,
+				resourceSetV6,
+				resourceSetV7,
 			},
 			NewRuntimeObjectFunc: func() runtime.Object {
 				return new(v1alpha1.ChartConfig)

--- a/service/controller/chartconfig/chart_config.go
+++ b/service/controller/chartconfig/chart_config.go
@@ -98,13 +98,14 @@ func NewChartConfig(config Config) (*ChartConfig, error) {
 	var chartConfigController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:       v1alpha1.NewChartConfigCRD(),
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
+			CRD:          v1alpha1.NewChartConfigCRD(),
+			K8sClient:    config.K8sClient,
+			Logger:       config.Logger,
 			ResourceSets: []*controller.ResourceSet{
-				resourceSetV5,
-				resourceSetV6,
-				resourceSetV7,
+				// Just disable resource sets for now.
+				// resourceSetV5,
+				// resourceSetV6,
+				// resourceSetV7,
 			},
 			NewRuntimeObjectFunc: func() runtime.Object {
 				return new(v1alpha1.ChartConfig)

--- a/service/service.go
+++ b/service/service.go
@@ -221,6 +221,8 @@ func (s *Service) Boot(ctx context.Context) {
 
 		// Start the controllers
 		go s.chartController.Boot(ctx)
-		go s.chartConfigController.Boot(ctx)
+
+		// Disable chartconfig controller. It will be removed separately.
+		// go s.chartConfigController.Boot(ctx)
 	})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -221,6 +221,6 @@ func (s *Service) Boot(ctx context.Context) {
 
 		// Start the controllers
 		go s.chartController.Boot(ctx)
-		go s.chartConfigController.Boot(ctx)
+		// go s.chartConfigController.Boot(ctx)
 	})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -221,8 +221,6 @@ func (s *Service) Boot(ctx context.Context) {
 
 		// Start the controllers
 		go s.chartController.Boot(ctx)
-
-		// Disable chartconfig controller. It will be removed separately.
-		// go s.chartConfigController.Boot(ctx)
+		go s.chartConfigController.Boot(ctx)
 	})
 }


### PR DESCRIPTION
Towards giantswarm/roadmap#30

Adds new chartmigration resource with a new migration integration test.

The migration resource removes the finalizer once cluster-operator has added an annotation to signal that the migration is complete.

With the new migration resource the legacy chartconfig controller can be disabled. It will be removed in follow up PRs.