### PR TITLE
Make kubernetes domain configurable

### DIFF
--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -52,9 +52,9 @@ spec:
         - {{ . }}
         {{- end }}
         searches:
-        - giantswarm.svc.cluster.local
-        - svc.cluster.local
-        - cluster.local
+        - giantswarm.svc.{{ .Values.cluster.kubernetes.domain }}
+        - svc.{{ .Values.cluster.kubernetes.domain }}
+        - {{ .Values.cluster.kubernetes.domain }}
         options:
         - name: ndots
           value: "5"

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -41,3 +41,7 @@ resource:
 
 tiller:
   namespace: "kube-system"
+
+cluster:
+  kubernetes:
+    domain: cluster.local


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8979

This will allow setting the proper search domain if is has been changed in the installation, the value is being taken from the same place as CoreDNS.