### PR TITLE
Wait for deleted helm release before removing finalizer

### DIFF
--- a/service/controller/chart/v1/resource/release/delete.go
+++ b/service/controller/chart/v1/resource/release/delete.go
@@ -3,8 +3,12 @@ package release
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/operatorkit/resource/crud"
 	"k8s.io/helm/pkg/helm"
 )
@@ -23,7 +27,40 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", releaseState.Name))
+		var rel *helmclient.ReleaseContent
+		{
+			o := func() error {
+				rel, err = r.helmClient.GetReleaseContent(ctx, releaseState.Name)
+				if rel != nil {
+					return microerror.Maskf(waitError, "release %#q still exists", releaseState.Name)
+				} else if helmclient.IsNotFound(err) {
+					// Fall through as release is deleted.
+					return nil
+				} else if err != nil {
+					return microerror.Mask(err)
+				}
+
+				return nil
+			}
+			b := backoff.NewMaxRetries(3, 5*time.Second)
+			n := backoff.NewNotifier(r.logger, ctx)
+
+			err := backoff.RetryNotify(o, b, n)
+			if IsWait(err) {
+				// We timed out and the helm release still exists. We cancel the
+				// resource and keep the finalizer. We will retry the delete in
+				// the next reconciliation loop.
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to delete release %#q", releaseState.Name))
+				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+				resourcecanceledcontext.SetCanceled(ctx)
+				return nil
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", releaseState.Name))
+		}
+
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting release %#q", releaseState.Name))
 	}

--- a/service/controller/chart/v1/resource/release/error.go
+++ b/service/controller/chart/v1/resource/release/error.go
@@ -20,6 +20,15 @@ func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
 
+var waitError = &microerror.Error{
+	Kind: "waitError",
+}
+
+// IsWait asserts waitError.
+func IsWait(err error) bool {
+	return microerror.Cause(err) == waitError
+}
+
 var wrongTypeError = &microerror.Error{
 	Kind: "wrongTypeError",
 }

--- a/service/controller/chart/v1/resource/release/error.go
+++ b/service/controller/chart/v1/resource/release/error.go
@@ -11,15 +11,6 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
-var invalidExecutionError = &microerror.Error{
-	Kind: "invalidExecutionError",
-}
-
-// IsInvalidExecution asserts invalidExecutionError.
-func IsInvalidExecution(err error) bool {
-	return microerror.Cause(err) == invalidExecutionError
-}
-
 var notFoundError = &microerror.Error{
 	Kind: "notFoundError",
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9081

When installing or updating helm releases we set wait=true so we wait for changes to be applied. For deleting releases is this is not supported by Helm 3 or 2 (see https://github.com/helm/helm/issues/2378).

So this extends the release resource to confirm the helm release is actually deleted before removing the finalizer.