### PR TITLE
Remove backoff when deleting releases

### DIFF
--- a/service/controller/chart/v1/resource/release/delete.go
+++ b/service/controller/chart/v1/resource/release/delete.go
@@ -41,7 +41,6 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
-
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting release %#q", releaseState.Name))
 	}

--- a/service/controller/chart/v1/resource/release/delete.go
+++ b/service/controller/chart/v1/resource/release/delete.go
@@ -3,9 +3,7 @@ package release
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
@@ -24,44 +22,24 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 
 		err = r.helmClient.DeleteRelease(ctx, releaseState.Name, helm.DeletePurge(true))
 		if helmclient.IsReleaseNotFound(err) {
-			// Fall through.
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q already deleted", releaseState.Name))
 			return nil
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
 
-		var rel *helmclient.ReleaseContent
-		{
-			o := func() error {
-				rel, err = r.helmClient.GetReleaseContent(ctx, releaseState.Name)
-				if rel != nil {
-					return microerror.Maskf(waitError, "release %#q still exists", releaseState.Name)
-				} else if helmclient.IsReleaseNotFound(err) {
-					// Fall through.
-					return nil
-				} else if err != nil {
-					return microerror.Mask(err)
-				}
-
-				return nil
-			}
-			b := backoff.NewMaxRetries(3, 5*time.Second)
-			n := backoff.NewNotifier(r.logger, ctx)
-
-			err := backoff.RetryNotify(o, b, n)
-			if IsWait(err) {
-				// We timed out and the helm release still exists. We cancel the
-				// resource and keep the finalizer. We will retry the delete in
-				// the next reconciliation loop.
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to delete release %#q", releaseState.Name))
-				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-				resourcecanceledcontext.SetCanceled(ctx)
-				return nil
-			} else if err != nil {
-				return microerror.Mask(err)
-			}
-
+		rel, err := r.helmClient.GetReleaseContent(ctx, releaseState.Name)
+		if rel != nil {
+			// Release still exists. We cancel the resource and keep the finalizer.
+			// We will retry the delete in the next reconciliation loop.
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q still exists", releaseState.Name))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			resourcecanceledcontext.SetCanceled(ctx)
+			return nil
+		} else if helmclient.IsReleaseNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", releaseState.Name))
+		} else if err != nil {
+			return microerror.Mask(err)
 		}
 
 	} else {

--- a/service/controller/chart/v1/resource/release/delete.go
+++ b/service/controller/chart/v1/resource/release/delete.go
@@ -34,9 +34,13 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			// Release still exists. We cancel the resource and keep the finalizer.
 			// We will retry the delete in the next reconciliation loop.
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q still exists", releaseState.Name))
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-			resourcecanceledcontext.SetCanceled(ctx)
+
 			finalizerskeptcontext.SetKept(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
 			return nil
 		} else if helmclient.IsReleaseNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", releaseState.Name))

--- a/service/controller/chart/v1/resource/release/delete.go
+++ b/service/controller/chart/v1/resource/release/delete.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/operatorkit/resource/crud"
 	"k8s.io/helm/pkg/helm"
@@ -35,6 +36,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q still exists", releaseState.Name))
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			resourcecanceledcontext.SetCanceled(ctx)
+			finalizerskeptcontext.SetKept(ctx)
 			return nil
 		} else if helmclient.IsReleaseNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", releaseState.Name))


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/chart-operator/pull/360.

Removing the backoff. This is just for finalizer management. If the release is not deleted yet it's OK to wait for the next loop.