### PR TITLE
Remove chartconfig usage from Tiller metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.12.1] 2020-03-10
+
+### Removed
+
+- Remove usage of legacy chartconfig CRs in Tiller metrics.
+
 ## [v0.12.0] 2020-03-09
 
 ### Added

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -7,7 +7,6 @@ const (
 
 const (
 	labelChart         = "chart_name"
-	labelChannel       = "channel_name"
 	labelRelease       = "release_name"
 	labelReleaseStatus = "release_status"
 	labelNamespace     = "namespace"

--- a/service/collector/tiller_max_history.go
+++ b/service/collector/tiller_max_history.go
@@ -80,7 +80,7 @@ func (t *TillerMaxHistory) Collect(ch chan<- prometheus.Metric) error {
 	}
 
 	if len(charts.Items) == 0 {
-		// Skip checking Tiller when there are no chart CRs,
+		// Skip checking Tiller when there are no chart CRs.
 		// As Tiller is only installed when there is at least one CR to reconcile.
 		t.logger.Log("level", "debug", "message", "did not collect Tiller max history")
 		t.logger.Log("level", "debug", "message", "no Chart or ChartConfig CRs in the cluster")

--- a/service/collector/tiller_max_history.go
+++ b/service/collector/tiller_max_history.go
@@ -79,14 +79,9 @@ func (t *TillerMaxHistory) Collect(ch chan<- prometheus.Metric) error {
 		return microerror.Mask(err)
 	}
 
-	chartConfigs, err := t.g8sClient.CoreV1alpha1().ChartConfigs("").List(metav1.ListOptions{})
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	if len(charts.Items) == 0 && len(chartConfigs.Items) == 0 {
-		// Skip checking tiller when there are no custom resources,
-		// as tiller is only installed when there is at least one CR to reconcile.
+	if len(charts.Items) == 0 {
+		// Skip checking Tiller when there are no chart CRs,
+		// As Tiller is only installed when there is at least one CR to reconcile.
 		t.logger.Log("level", "debug", "message", "did not collect Tiller max history")
 		t.logger.Log("level", "debug", "message", "no Chart or ChartConfig CRs in the cluster")
 

--- a/service/collector/tiller_reachable.go
+++ b/service/collector/tiller_reachable.go
@@ -78,14 +78,9 @@ func (t *TillerReachable) Collect(ch chan<- prometheus.Metric) error {
 		return microerror.Mask(err)
 	}
 
-	chartConfigs, err := t.g8sClient.CoreV1alpha1().ChartConfigs("").List(metav1.ListOptions{})
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	if len(charts.Items) == 0 && len(chartConfigs.Items) == 0 {
-		// Skip pinging tiller when there are no custom resources,
-		// as tiller is only installed when there is at least one CR to reconcile.
+	if len(charts.Items) == 0 {
+		// Skip pinging tiller when there are no chart CRs,
+		// As Tiller is only installed when there is at least one CR to reconcile.
 		t.logger.Log("level", "debug", "message", "did not collect Tiller reachability")
 		t.logger.Log("level", "debug", "message", "no Chart or ChartConfig CRs in the cluster")
 

--- a/service/collector/tiller_reachable.go
+++ b/service/collector/tiller_reachable.go
@@ -79,7 +79,7 @@ func (t *TillerReachable) Collect(ch chan<- prometheus.Metric) error {
 	}
 
 	if len(charts.Items) == 0 {
-		// Skip pinging tiller when there are no chart CRs,
+		// Skip pinging tiller when there are no chart CRs.
 		// As Tiller is only installed when there is at least one CR to reconcile.
 		t.logger.Log("level", "debug", "message", "did not collect Tiller reachability")
 		t.logger.Log("level", "debug", "message", "no Chart or ChartConfig CRs in the cluster")

--- a/service/collector/tiller_running_pods.go
+++ b/service/collector/tiller_running_pods.go
@@ -78,14 +78,9 @@ func (t *TillerRunningPods) Collect(ch chan<- prometheus.Metric) error {
 		return microerror.Mask(err)
 	}
 
-	chartConfigs, err := t.g8sClient.CoreV1alpha1().ChartConfigs("").List(metav1.ListOptions{})
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	if len(charts.Items) == 0 && len(chartConfigs.Items) == 0 {
-		// Skip pinging tiller when there are no custom resources,
-		// as tiller is only installed when there is at least one CR to reconcile.
+	if len(charts.Items) == 0 {
+		// Skip pinging Tiller when there are no chart CRs.
+		// As Tiller is only installed when there is at least one CR to reconcile.
 		t.logger.Log("level", "debug", "message", "did not collect Tiller running pods")
 		t.logger.Log("level", "debug", "message", "no Chart or ChartConfig CRs in the cluster")
 


### PR DESCRIPTION
Towards giantswarm/roadmap#30

I missed removing some chartconfig code from the Tiller metrics. Getting it sorted.

```
E 03/10 19:50:29 failed collecting metrics | exporterkit/collector/set.go:92
	/go/src/github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/exporterkit/collector/set.go:92:
	/go/src/github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/exporterkit/collector/set.go:83:
	/go/src/github.com/giantswarm/chart-operator/service/collector/tiller_max_history.go:84:
	the server could not find the requested resource (get chartconfigs.core.giantswarm.io)
```
