### PR TITLE
helm3: Remove usage of e2e-harness in integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,8 @@ go 1.13
 require (
 	github.com/chai2010/gettext-go v0.0.0-20191225085308-6b9f4b1008e1 // indirect
 	github.com/giantswarm/apiextensions v0.1.0
-	github.com/giantswarm/apprclient v0.0.0-20191209123802-955b7e89e6e2 // indirect
+	github.com/giantswarm/appcatalog v0.1.11
 	github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192
-	github.com/giantswarm/e2e-harness v0.1.1-0.20191209145255-b2048d8645c1
 	github.com/giantswarm/e2esetup v0.0.0-20191209131007-01b9f9061692
 	github.com/giantswarm/exporterkit v0.0.0-20190619131829-9749deade60f
 	github.com/giantswarm/helmclient v0.0.0-20200205160527-61453b0b25de

--- a/go.sum
+++ b/go.sum
@@ -170,13 +170,11 @@ github.com/giantswarm/apiextensions v0.0.0-20200127104704-78e994410a10 h1:SrUZM6
 github.com/giantswarm/apiextensions v0.0.0-20200127104704-78e994410a10/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
 github.com/giantswarm/apiextensions v0.1.0 h1:jpmwpNTMxa49ue4p1zUIAqXscWPvxN5EB4dUFWG4wr4=
 github.com/giantswarm/apiextensions v0.1.0/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
-github.com/giantswarm/apprclient v0.0.0-20191209123802-955b7e89e6e2 h1:AfmrYPVlmiZrEKvg2jVYVDpEVOZVQC7W+M1jiImTp1U=
-github.com/giantswarm/apprclient v0.0.0-20191209123802-955b7e89e6e2/go.mod h1:ajQ3Ibi4dmgMXu23nen/yFp1SaySeQDK3xvXZSKCnCc=
+github.com/giantswarm/appcatalog v0.1.11 h1:VM1fOBBVDSn23nbzTr6W4POC3c/6O9xm0pUUTr1XRI0=
+github.com/giantswarm/appcatalog v0.1.11/go.mod h1:jxC7n+2+TP/ub8kmbIZQ+qcVM55LixRhPP+KznTbKnQ=
 github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192 h1:jguq2nu1gbvP6OQIqmkUlbl4ekpwSRUPiXUWlF8InyQ=
 github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192/go.mod h1:kjItv/iHgl/xsprYgbnCOme1pVTiiiaZeR2ybsN4ab0=
 github.com/giantswarm/e2e-harness v0.1.1-0.20191209134222-be7852f38d3e/go.mod h1:Vn1HSRdeIgOjYaPRX6p9uzhdwuCn9guM5QEEiLUUb2w=
-github.com/giantswarm/e2e-harness v0.1.1-0.20191209145255-b2048d8645c1 h1:y9NtQNaVNiAG+swx/8sJfUfAqGGantk+BsvZVOcz3lw=
-github.com/giantswarm/e2e-harness v0.1.1-0.20191209145255-b2048d8645c1/go.mod h1:Vn1HSRdeIgOjYaPRX6p9uzhdwuCn9guM5QEEiLUUb2w=
 github.com/giantswarm/e2esetup v0.0.0-20191209131007-01b9f9061692 h1:Bf4dI6D480xUnZ7rPI8d3jKFPCffm+rzxRWk3076Ta4=
 github.com/giantswarm/e2esetup v0.0.0-20191209131007-01b9f9061692/go.mod h1:p+cP+0Aa2AtnwKi2A4CeNcIgP4nb1no23hnVqCWegp0=
 github.com/giantswarm/errors v0.0.0-20200205145547-c12c94d9a110 h1:v8MizGt0iKYaM3PI40psbw3qKgQAfasrJR79tL7N5UI=
@@ -191,6 +189,7 @@ github.com/giantswarm/k8sportforward v0.0.0-20191209165148-21368288d82d h1:nySwi
 github.com/giantswarm/k8sportforward v0.0.0-20191209165148-21368288d82d/go.mod h1:zmkvHSUauFv31WnGl67dEC5zy9CE72KEd/mQ23DvmkU=
 github.com/giantswarm/microendpoint v0.0.0-20200205204116-c2c5b3af4bdb h1:kVDeYhuUaXMSrNlFuArEi/UsYE8WevFkB4v3PE0REbQ=
 github.com/giantswarm/microendpoint v0.0.0-20200205204116-c2c5b3af4bdb/go.mod h1:IivF0ieDmYEjeYULde8aupgXHYBb8N/XR4TEA+WkSO8=
+github.com/giantswarm/microerror v0.0.0-20191011121515-e0ebc4ecf5a5/go.mod h1://Lo9dKJ8P2TBciuky5fDHEItccyvZOWE+B/0JiJT8A=
 github.com/giantswarm/microerror v0.1.1-0.20200205143715-01b76f66cae6 h1:lJr756ZiXB9+n9pCUjMMNKKf+Lli3qQsybugFxx7Gjo=
 github.com/giantswarm/microerror v0.1.1-0.20200205143715-01b76f66cae6/go.mod h1://Lo9dKJ8P2TBciuky5fDHEItccyvZOWE+B/0JiJT8A=
 github.com/giantswarm/microerror v0.2.0 h1:SaE7S34mp/wEiQkgtPiq8wQbNUTCj1gjiCWPjO3wgJo=
@@ -408,6 +407,7 @@ github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/juju/errgo v0.0.0-20140925100237-08cceb5d0b53/go.mod h1:ZtgUe3RyZisw/AlQjgU9DeO3hqUH9E/bkreI2FLg/QY=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/integration/key/catalog.go
+++ b/integration/key/catalog.go
@@ -1,0 +1,9 @@
+package key
+
+func DefaultCatalogStorageURL() string {
+	return "https://giantswarm.github.com/default-catalog"
+}
+
+func DefaultTestCatalogStorageURL() string {
+	return "https://giantswarm.github.com/default-test-catalog"
+}

--- a/integration/key/namespace.go
+++ b/integration/key/namespace.go
@@ -1,0 +1,5 @@
+package key
+
+func Namespace() string {
+	return "giantswarm"
+}

--- a/integration/key/release_name.go
+++ b/integration/key/release_name.go
@@ -1,6 +1,6 @@
 package key
 
-func ChartOperatorReleaseName() string {
+func ReleaseName() string {
 	return "chart-operator"
 }
 

--- a/integration/release/error.go
+++ b/integration/release/error.go
@@ -1,0 +1,32 @@
+package release
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var releaseStatusNotMatchingError = &microerror.Error{
+	Kind: "releaseStatusNotMatchingError",
+}
+
+// IsReleaseStatusNotMatching asserts releaseStatusNotMatchingError
+func IsReleaseStatusNotMatching(err error) bool {
+	return microerror.Cause(err) == releaseStatusNotMatchingError
+}
+
+var releaseVersionNotMatchingError = &microerror.Error{
+	Kind: "releaseVersionNotMatchingError",
+}
+
+// IsReleaseVersionNotMatching asserts releaseVersionNotMatchingError
+func IsReleaseVersionNotMatching(err error) bool {
+	return microerror.Cause(err) == releaseVersionNotMatchingError
+}

--- a/integration/release/release.go
+++ b/integration/release/release.go
@@ -1,0 +1,89 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/helmclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+type Config struct {
+	HelmClient *helmclient.Client
+	Logger     micrologger.Logger
+}
+
+type Release struct {
+	helmClient *helmclient.Client
+	logger     micrologger.Logger
+}
+
+func New(config Config) (*Release, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.HelmClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HelmClient must not be empty", config)
+	}
+
+	r := &Release{
+		helmClient: config.HelmClient,
+		logger:     config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Release) WaitForChartInfo(ctx context.Context, release, version string) error {
+	operation := func() error {
+		rh, err := r.helmClient.GetReleaseHistory(ctx, release)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		if rh.Version != version {
+			return microerror.Maskf(releaseVersionNotMatchingError, "waiting for '%s', current '%s'", version, rh.Version)
+		}
+		return nil
+	}
+
+	notify := func(err error, t time.Duration) {
+		r.logger.Log("level", "debug", "message", fmt.Sprintf("failed to get release version '%s': retrying in %s", version, t), "stack", fmt.Sprintf("%v", err))
+	}
+
+	b := backoff.NewExponential(backoff.ShortMaxWait, backoff.LongMaxInterval)
+	err := backoff.RetryNotify(operation, b, notify)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	return nil
+}
+
+func (r *Release) WaitForStatus(ctx context.Context, release, status string) error {
+	operation := func() error {
+		rc, err := r.helmClient.GetReleaseContent(ctx, release)
+		if helmclient.IsReleaseNotFound(err) && status == "DELETED" {
+			// Error is expected because we purge releases when deleting.
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		if rc.Status != status {
+			return microerror.Maskf(releaseStatusNotMatchingError, "waiting for '%s', current '%s'", status, rc.Status)
+		}
+		return nil
+	}
+
+	notify := func(err error, t time.Duration) {
+		r.logger.Log("level", "debug", "message", fmt.Sprintf("failed to get release status '%s': retrying in %s", status, t), "stack", fmt.Sprintf("%v", err))
+	}
+
+	b := backoff.NewExponential(backoff.MediumMaxWait, backoff.LongMaxInterval)
+	err := backoff.RetryNotify(operation, b, notify)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	return nil
+}

--- a/integration/setup/config.go
+++ b/integration/setup/config.go
@@ -1,12 +1,13 @@
 package setup
 
 import (
-	"github.com/giantswarm/e2e-harness/pkg/release"
 	"github.com/giantswarm/e2esetup/chart/env"
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/chart-operator/integration/release"
 )
 
 const (
@@ -15,9 +16,9 @@ const (
 )
 
 type Config struct {
-	HelmClient *helmclient.Client
+	HelmClient helmclient.Interface
 	K8s        *k8sclient.Setup
-	K8sClients *k8sclient.Clients
+	K8sClients k8sclient.Interface
 	Logger     micrologger.Logger
 	Release    *release.Release
 }
@@ -80,13 +81,8 @@ func NewConfig() (Config, error) {
 	var newRelease *release.Release
 	{
 		c := release.Config{
-			ExtClient:  cpK8sClients.ExtClient(),
-			G8sClient:  cpK8sClients.G8sClient(),
 			HelmClient: helmClient,
-			K8sClient:  cpK8sClients.K8sClient(),
 			Logger:     logger,
-
-			Namespace: namespace,
 		}
 
 		newRelease, err = release.New(c)

--- a/integration/setup/config.go
+++ b/integration/setup/config.go
@@ -6,8 +6,8 @@ import (
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/chart-operator/integration/key"
 	"github.com/giantswarm/chart-operator/integration/release"
 )
 
@@ -65,7 +65,7 @@ func NewConfig() (Config, error) {
 			Logger:               logger,
 			K8sClient:            cpK8sClients.K8sClient(),
 			RestConfig:           cpK8sClients.RESTConfig(),
-			TillerNamespace:      key.Namespace(),
+			TillerNamespace:      metav1.NamespaceSystem,
 			TillerUpgradeEnabled: true,
 		}
 		helmClient, err = helmclient.New(c)

--- a/integration/setup/config.go
+++ b/integration/setup/config.go
@@ -7,12 +7,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
+	"github.com/giantswarm/chart-operator/integration/key"
 	"github.com/giantswarm/chart-operator/integration/release"
-)
-
-const (
-	namespace       = "giantswarm"
-	tillerNamespace = "kube-system"
 )
 
 type Config struct {
@@ -69,7 +65,7 @@ func NewConfig() (Config, error) {
 			Logger:               logger,
 			K8sClient:            cpK8sClients.K8sClient(),
 			RestConfig:           cpK8sClients.RESTConfig(),
-			TillerNamespace:      tillerNamespace,
+			TillerNamespace:      key.Namespace(),
 			TillerUpgradeEnabled: true,
 		}
 		helmClient, err = helmclient.New(c)

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -51,6 +51,13 @@ func installResources(ctx context.Context, config Config) error {
 		}
 	}
 
+	{
+		err := config.HelmClient.EnsureTillerInstalled(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	var latestOperatorRelease string
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("getting latest %#q release", project.Name()))

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -7,14 +7,19 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
-	"github.com/giantswarm/e2e-harness/pkg/release"
+	"github.com/giantswarm/appcatalog"
+	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
+	"github.com/spf13/afero"
+	"k8s.io/helm/pkg/helm"
 
 	"github.com/giantswarm/chart-operator/integration/env"
 	"github.com/giantswarm/chart-operator/integration/key"
 	"github.com/giantswarm/chart-operator/integration/templates"
+	"github.com/giantswarm/chart-operator/pkg/project"
 )
 
 func Setup(m *testing.M, config Config) {
@@ -40,24 +45,85 @@ func installResources(ctx context.Context, config Config) error {
 	var err error
 
 	{
-		err := config.K8s.EnsureNamespaceCreated(ctx, namespace)
+		err := config.K8s.EnsureNamespaceCreated(ctx, key.Namespace())
 		if err != nil {
 			return microerror.Mask(err)
 		}
 	}
 
+	var latestOperatorRelease string
 	{
-		err = config.HelmClient.EnsureTillerInstalled(ctx)
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("getting latest %#q release", project.Name()))
+
+		latestOperatorRelease, err = appcatalog.GetLatestVersion(ctx, key.DefaultCatalogStorageURL(), project.Name())
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("latest %#q release is %#q", project.Name(), latestOperatorRelease))
+	}
+
+	var operatorTarballPath string
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "getting tarball URL")
+
+		// TODO: Use project.Version() once the operator is flattened.
+		//
+		//	https://github.com/giantswarm/giantswarm/issues/7896
+		//
+		operatorVersion := fmt.Sprintf("%s-%s", latestOperatorRelease, env.CircleSHA())
+		operatorTarballURL, err := appcatalog.NewTarballURL(key.DefaultTestCatalogStorageURL(), project.Name(), operatorVersion)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tarball URL is %#q", operatorTarballURL))
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "pulling tarball")
+
+		operatorTarballPath, err = config.HelmClient.PullChartTarball(ctx, operatorTarballURL)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tarball path is %#q", operatorTarballPath))
 	}
 
 	{
-		err = config.Release.InstallOperator(ctx, key.ChartOperatorReleaseName(), release.NewVersion(env.CircleSHA()), templates.ChartOperatorValues, v1alpha1.NewChartCRD())
+		defer func() {
+			fs := afero.NewOsFs()
+			err := fs.Remove(operatorTarballPath)
+			if err != nil {
+				config.Logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %#q failed", operatorTarballPath), "stack", fmt.Sprintf("%#v", err))
+			}
+		}()
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installing %#q", project.Name()))
+
+		err = config.HelmClient.InstallReleaseFromTarball(ctx,
+			operatorTarballPath,
+			key.Namespace(),
+			helm.ReleaseName(key.ReleaseName()),
+			helm.ValueOverrides([]byte(templates.ChartOperatorValues)),
+			helm.InstallWait(true))
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installed %#q", project.Name()))
+	}
+
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring chart CRD exists")
+
+		// The operator will install the CRD on boot but we create chart CRs
+		// in the tests so this ensures the CRD is present.
+		err = config.K8sClients.CRDClient().EnsureCreated(ctx, v1alpha1.NewChartCRD(), backoff.NewMaxRetries(7, 1*time.Second))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensured chart CRD exists")
 	}
 
 	return nil

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -45,14 +45,14 @@ func installResources(ctx context.Context, config Config) error {
 	var err error
 
 	{
-		err := config.K8s.EnsureNamespaceCreated(ctx, key.Namespace())
+		err = config.K8s.EnsureNamespaceCreated(ctx, key.Namespace())
 		if err != nil {
 			return microerror.Mask(err)
 		}
 	}
 
 	{
-		err := config.HelmClient.EnsureTillerInstalled(ctx)
+		err = config.HelmClient.EnsureTillerInstalled(ctx)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -6,5 +6,5 @@ package templates
 const ChartOperatorValues = `cnr:
   address: http://cnr-server:5000
 clusterDNSIP: 10.96.0.10
-e2e: true
+e2e: false
 `

--- a/integration/test/chart/basic/basic_test.go
+++ b/integration/test/chart/basic/basic_test.go
@@ -35,19 +35,19 @@ func TestChartLifecycle(t *testing.T) {
 		cr := &v1alpha1.Chart{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      key.TestAppReleaseName(),
-				Namespace: "giantswarm",
+				Namespace: key.Namespace(),
 				Labels: map[string]string{
 					"chart-operator.giantswarm.io/version": "1.0.0",
 				},
 			},
 			Spec: v1alpha1.ChartSpec{
 				Name:       key.TestAppReleaseName(),
-				Namespace:  "giantswarm",
+				Namespace:  key.Namespace(),
 				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz",
 				Version:    "0.7.0",
 			},
 		}
-		_, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(cr)
+		_, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.Namespace()).Create(cr)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -68,7 +68,7 @@ func TestChartLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking status for chart CR %#q", key.TestAppReleaseName()))
 
-		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
+		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.Namespace()).Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -83,7 +83,7 @@ func TestChartLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart %#q", key.TestAppReleaseName()))
 
-		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
+		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.Namespace()).Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -91,7 +91,7 @@ func TestChartLifecycle(t *testing.T) {
 		cr.Spec.TarballURL = "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.1.tgz"
 		cr.Spec.Version = "0.7.1"
 
-		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Update(cr)
+		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.Namespace()).Update(cr)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -112,7 +112,7 @@ func TestChartLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chart %#q", key.TestAppReleaseName()))
 
-		err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
+		err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.Namespace()).Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}

--- a/integration/test/chart/migration/migration_test.go
+++ b/integration/test/chart/migration/migration_test.go
@@ -56,7 +56,7 @@ func TestChartMigration(t *testing.T) {
 		chartConfig := &corev1alpha1.ChartConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      key.TestAppReleaseName(),
-				Namespace: "giantswarm",
+				Namespace: key.Namespace(),
 				Finalizers: []string{
 					// Finalizer is created manually because there is no
 					// chartconfig controller.
@@ -70,7 +70,7 @@ func TestChartMigration(t *testing.T) {
 				Chart: corev1alpha1.ChartConfigSpecChart{
 					Channel:   "0-7-beta",
 					Name:      key.TestAppReleaseName(),
-					Namespace: "giantswarm",
+					Namespace: key.Namespace(),
 					Release:   key.TestAppReleaseName(),
 				},
 				VersionBundle: corev1alpha1.ChartConfigSpecVersionBundle{
@@ -78,7 +78,7 @@ func TestChartMigration(t *testing.T) {
 				},
 			},
 		}
-		_, err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs("giantswarm").Create(chartConfig)
+		_, err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs(key.Namespace()).Create(chartConfig)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -93,7 +93,7 @@ func TestChartMigration(t *testing.T) {
 		chart := &v1alpha1.Chart{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      key.TestAppReleaseName(),
-				Namespace: "giantswarm",
+				Namespace: key.Namespace(),
 				Labels: map[string]string{
 					"app":                                  "test-app",
 					"chart-operator.giantswarm.io/version": "1.0.0",
@@ -101,11 +101,11 @@ func TestChartMigration(t *testing.T) {
 			},
 			Spec: v1alpha1.ChartSpec{
 				Name:       key.TestAppReleaseName(),
-				Namespace:  "giantswarm",
+				Namespace:  key.Namespace(),
 				TarballURL: "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz",
 			},
 		}
-		_, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts("giantswarm").Create(chart)
+		_, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.Namespace()).Create(chart)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -129,7 +129,7 @@ func TestChartMigration(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("adding annotation to chartconfig %#q", key.TestAppReleaseName()))
 
-		chartConfig, err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
+		chartConfig, err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs(key.Namespace()).Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -143,7 +143,7 @@ func TestChartMigration(t *testing.T) {
 		annotations[annotation.DeleteCustomResourceOnly] = "true"
 		chartConfig.Annotations = annotations
 
-		_, err = config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs("giantswarm").Update(chartConfig)
+		_, err = config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs(key.Namespace()).Update(chartConfig)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -155,7 +155,7 @@ func TestChartMigration(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chartconfig %#q", key.TestAppReleaseName()))
 
-		err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs("giantswarm").Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
+		err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs(key.Namespace()).Delete(key.TestAppReleaseName(), &metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -168,7 +168,7 @@ func TestChartMigration(t *testing.T) {
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking chartconfig %#q was deleted", key.TestAppReleaseName()))
 
 		o := func() error {
-			_, err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
+			_, err := config.K8sClients.G8sClient().CoreV1alpha1().ChartConfigs(key.Namespace()).Get(key.TestAppReleaseName(), metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
 				// Error is expected because finalizer was removed.
 				return nil


### PR DESCRIPTION
Towards giantswarm/roadmap#30

e2e-harness uses helmclient. So this kills 2 birds with one stone by moving the setup code into the operator.