### PR TITLE
Add missing values to fix integration tests

### DIFF
--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -7,4 +7,12 @@ const ChartOperatorValues = `cnr:
   address: http://cnr-server:5000
 clusterDNSIP: 10.96.0.10
 e2e: true
+
+Installation:
+  V1:
+    Helm:
+      HTTP:
+        ClientTimeout: 30s
+    Registry:
+      Domain: quay.io
 `


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/chart-operator/pull/402 to fix the integration tests.

@xh3b4sd Hope you don't mind me adding you too. As we were discussing in the last PR.

The draughtsman values are used for the control plane catalog. So I think its best if they are in the test template since they're used.



