### PR TITLE
Update orb version and set AppVersion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.8.3
+  architect: giantswarm/architect@0.8.6
 
 jobs:
   build:

--- a/helm/chart-operator/Chart.yaml
+++ b/helm/chart-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: chart-operator
 description: A Helm chart for the chart-operator
 home: https://github.com/giantswarm/chart-operator
-appVersion: [[ .Version ]]
+appVersion: [[ .AppVersion ]]
 version: [[ .Version ]]


### PR DESCRIPTION
Tagging 0.12.2 earlier failed I think due to the AppVersion templating.

Also updating architect-orb to latest so we use medium Circle VMs in CI to reduce annoying KIND cluster failures.