### PR TITLE
Deploy as an app CR in control planes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ workflows:
           test-dir: "integration/test/chart/basic"
           requires:
           - build
+          - push-chart-operator-to-default-app-catalog
       
       - architect/integration-test:
           context: architect
@@ -137,3 +138,4 @@ workflows:
           test-dir: "integration/test/chart/migration"
           requires:
           - build
+          - push-chart-operator-to-default-app-catalog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,8 @@ workflows:
           password_envar: "QUAY_PASSWORD"
           requires:
             - build
-          # Needed to trigger job also on git tag.
           filters:
+            # Trigger the job also on git tag.
             tags:
               only: /^v.*/
 
@@ -49,10 +49,10 @@ workflows:
           password_envar: "ALIYUN_PASSWORD"
           requires:
             - build
-          # Needed to trigger job only on git tag.
           filters:
             branches:
               only: master
+            # Trigger the job also on git tag.
             tags:
               only: /^v.*/
 
@@ -64,8 +64,8 @@ workflows:
           chart: "chart-operator"
           requires:
             - push-chart-operator-to-quay
+            - push-chart-operator-to-aliyun
           filters:
-            # Needed to trigger job also on git tag.
             tags:
               only: /^v.*/
 
@@ -77,8 +77,8 @@ workflows:
           chart: "chart-operator"
           requires:
             - push-chart-operator-to-quay
+            - push-chart-operator-to-aliyun
           filters:
-            # Needed to trigger job also on git tag.
             tags:
               only: /^v.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.8.6
+  architect: giantswarm/architect@0.8.9
 
 jobs:
   build:
@@ -15,15 +15,10 @@ jobs:
     - run: ./architect build
     - store_test_results:
         path: /tmp/results
-    - run: ./architect publish --pipeline=false --channels=${CIRCLE_SHA1}
-    - run: |
-        sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/chart-operator-chart/Chart.yaml
-        ./architect publish --pipeline=false --channels=${CIRCLE_SHA1}
     - persist_to_workspace:
         root: .
         paths:
         - ./chart-operator
-        - ./architect
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,33 +25,6 @@ jobs:
         - ./chart-operator
         - ./architect
 
-  deploy:
-    machine: true
-    steps:
-    - checkout
-
-    - attach_workspace:
-        at: .
-
-    - run: ./architect deploy
-
-    - run:
-        name: publish to beta
-        command: ./architect publish
-    - run: |
-        sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/chart-operator-chart/Chart.yaml
-        ./architect publish
-
-  publish_to_stable:
-    machine: true
-    steps:
-    - checkout
-
-    - attach_workspace:
-        at: .
-
-    - run: ./architect publish --stable
-
 workflows:
   build:
     jobs:
@@ -86,16 +59,20 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker-legacy:
-          name: push-chart-operator-to-aliyun-legacy
-          image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/chart-operator"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
+      - architect/push-to-app-catalog:
+          name: push-chart-operator-to-control-plane-app-catalog
+          app_catalog: "control-plane-catalog"
+          app_catalog_test: "control-plane-test-catalog"
+          chart: "chart-operator"
           requires:
-            - build
+            - push-chart-operator-to-quay
+          filters:
+            # Needed to trigger job also on git tag.
+            tags:
+              only: /^v.*/
 
       - architect/push-to-app-catalog:
-          name: push-chart-operator-to-app-catalog
+          name: push-chart-operator-to-default-app-catalog
           app_catalog: "default-catalog"
           app_catalog_test: "default-test-catalog"
           chart: "chart-operator"
@@ -103,6 +80,45 @@ workflows:
             - push-chart-operator-to-quay
           filters:
             # Needed to trigger job also on git tag.
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: push-chart-operator-to-aws-app-collection
+          app_name: "chart-operator"
+          app_collection_repo: "aws-app-collection"
+          unique: "true"
+          requires:
+            - push-chart-operator-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: push-chart-operator-to-azure-app-collection
+          app_name: "chart-operator"
+          app_collection_repo: "azure-app-collection"
+          unique: "true"
+          requires:
+            - push-chart-operator-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: push-chart-operator-to-kvm-app-collection
+          app_name: "chart-operator"
+          app_collection_repo: "kvm-app-collection"
+          unique: "true"
+          requires:
+            - push-chart-operator-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v.*/
 
@@ -117,17 +133,3 @@ workflows:
           test-dir: "integration/test/chart/migration"
           requires:
           - build
-
-      - deploy:
-          filters:
-            branches:
-              only: master
-          requires:
-          - push-chart-operator-to-aliyun-legacy
-
-      - publish_to_stable:
-          filters:
-            branches:
-              only: master
-          requires:
-          - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-docker:
+          context: architect
           name: push-chart-operator-to-quay
           image: "quay.io/giantswarm/chart-operator"
           username_envar: "QUAY_USERNAME"
@@ -41,6 +42,7 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-docker:
+          context: architect
           name: push-chart-operator-to-aliyun
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/chart-operator"
           username_envar: "ALIYUN_USERNAME"
@@ -55,6 +57,7 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-catalog:
+          context: architect
           name: push-chart-operator-to-control-plane-app-catalog
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
@@ -67,6 +70,7 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-catalog:
+          context: architect
           name: push-chart-operator-to-default-app-catalog
           app_catalog: "default-catalog"
           app_catalog_test: "default-test-catalog"
@@ -79,6 +83,7 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
+          context: architect
           name: push-chart-operator-to-aws-app-collection
           app_name: "chart-operator"
           app_collection_repo: "aws-app-collection"
@@ -92,6 +97,7 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
+          context: architect
           name: push-chart-operator-to-azure-app-collection
           app_name: "chart-operator"
           app_collection_repo: "azure-app-collection"
@@ -105,6 +111,7 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
+          context: architect
           name: push-chart-operator-to-kvm-app-collection
           app_name: "chart-operator"
           app_collection_repo: "kvm-app-collection"
@@ -118,12 +125,14 @@ workflows:
               only: /^v.*/
 
       - architect/integration-test:
+          context: architect
           name: basic-integration-test
           test-dir: "integration/test/chart/basic"
           requires:
           - build
       
       - architect/integration-test:
+          context: architect
           name: migration-integration-test
           test-dir: "integration/test/chart/migration"
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Deploy as a unique app in app collection in control plane clusters.
+
 ## [v0.12.4] 2020-04-15
 
 ### Changed

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       {{- include "chart-operator.selectorLabels" . | nindent 6 }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Towards giantswarm/giantswarm#7896

This completes the flattening code changes. Needs https://github.com/giantswarm/app-operator/pull/255 to be merged first. 

Once this is merged we'll create a 0.13.0 release. We want to use major version 1 to distinguish chart-operator CRs using Helm 3.