### PR TITLE
Only update failed releases if the chart values or version has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+- Always set chart CR annotations so update state calculation is accurate.
 - Only update failed Helm releases if the chart values or version has changed.
 
 ## [v0.12.3] 2020-04-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Only update failed Helm releases if the chart values or version has changed.
+
 ## [v0.12.3] 2020-04-09
 
 ### Changed

--- a/service/controller/chart/resource/release/create.go
+++ b/service/controller/chart/resource/release/create.go
@@ -32,6 +32,13 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	if releaseState.Name != "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating release %#q", releaseState.Name))
 
+		// We set the checksum annotation so the update state calculation
+		// is accurate when we check in the next reconciliation loop.
+		err = r.patchAnnotations(ctx, cr, releaseState)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
 		ns := key.Namespace(cr)
 		tarballURL := key.TarballURL(cr)
 
@@ -90,13 +97,6 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		case <-ch:
 			// Fall through.
 		case <-time.After(3 * time.Second):
-			// We set the checksum annotation so the update state calculation
-			// is accurate when we check in the next reconciliation loop.
-			err = r.patchAnnotations(ctx, cr, releaseState)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-
 			r.logger.LogCtx(ctx, "level", "debug", "message", "release still being created")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
@@ -125,11 +125,6 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 				resourcecanceledcontext.SetCanceled(ctx)
 				return nil
 			}
-			return microerror.Mask(err)
-		}
-
-		err = r.patchAnnotations(ctx, cr, releaseState)
-		if err != nil {
 			return microerror.Mask(err)
 		}
 

--- a/service/controller/chart/resource/release/resource.go
+++ b/service/controller/chart/resource/release/resource.go
@@ -183,6 +183,29 @@ func isEmpty(c ReleaseState) bool {
 	return equals(c, ReleaseState{})
 }
 
+func isReleaseFailed(current, desired ReleaseState) bool {
+	if isEmpty(current) {
+		return false
+	}
+
+	// Values have changed so we will try to update the release.
+	if current.ValuesMD5Checksum != desired.ValuesMD5Checksum {
+		return false
+	}
+
+	// Version has changed so we will try to update the release.
+	if current.Version != desired.Version {
+		return false
+	}
+
+	// Release is failed and should not be updated.
+	if current.Status == helmFailedStatus {
+		return true
+	}
+
+	return false
+}
+
 func isReleaseInTransitionState(r ReleaseState) bool {
 	return releaseTransitionStatuses[r.Status]
 }

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -172,7 +172,16 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %#q release has to be updated", desiredReleaseState.Name))
 
+	// The release is still being updated so we don't update and check again
+	// in the next reconciliation loop.
 	if isReleaseInTransitionState(currentReleaseState) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q release is in status %#q and cannot be updated", desiredReleaseState.Name, currentReleaseState.Status))
+		return nil, nil
+	}
+
+	// The release is failed and the values and version have not changed. So we
+	// don't update. We will be alerted so we can investigate.
+	if isReleaseFailed(currentReleaseState, desiredReleaseState) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q release is in status %#q and cannot be updated", desiredReleaseState.Name, currentReleaseState.Status))
 		return nil, nil
 	}

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -35,6 +35,13 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	if releaseState.Name != "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release %#q with force == %t", releaseState.Name, upgradeForce))
 
+		// We set the checksum annotation so the update state calculation
+		// is accurate when we check in the next reconciliation loop.
+		err = r.patchAnnotations(ctx, cr, releaseState)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
 		tarballURL := key.TarballURL(cr)
 		tarballPath, err := r.helmClient.PullChartTarball(ctx, tarballURL)
 		if helmclient.IsPullChartFailedError(err) {
@@ -93,13 +100,6 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		case <-ch:
 			// Fall through.
 		case <-time.After(3 * time.Second):
-			// We set the checksum annotation so the update state calculation
-			// is accurate when we check in the next reconciliation loop.
-			err = r.patchAnnotations(ctx, cr, releaseState)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-
 			r.logger.LogCtx(ctx, "level", "debug", "message", "release still being updated")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
@@ -128,11 +128,6 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				resourcecanceledcontext.SetCanceled(ctx)
 				return nil
 			}
-			return microerror.Mask(err)
-		}
-
-		err = r.patchAnnotations(ctx, cr, releaseState)
-		if err != nil {
 			return microerror.Mask(err)
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10074

Currently if the release is FAILED we update since the release is not DEPLOYED. However if the values or version have not changed its likely the update will fail again.

This makes the reconciliation process less aggressive but still allows us to deploy fixes.