### PR TITLE
Remove e2e-harness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/giantswarm/apiextensions v0.2.3
+	github.com/giantswarm/appcatalog v0.1.11
 	github.com/giantswarm/backoff v0.2.0
-	github.com/giantswarm/e2e-harness v0.2.0
 	github.com/giantswarm/e2esetup v0.2.0
 	github.com/giantswarm/exporterkit v0.2.0
 	github.com/giantswarm/helmclient v0.2.2
@@ -23,6 +23,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
+	k8s.io/apiserver v0.16.6 // indirect
 	k8s.io/client-go v0.17.2
 	k8s.io/helm v2.16.4+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -202,12 +202,12 @@ github.com/giantswarm/apiextensions v0.2.0 h1:6gnfXFRL/eGqPbYhM7jUckwmulx7jh6qJp
 github.com/giantswarm/apiextensions v0.2.0/go.mod h1:iw66G0WDcrQl9mi2m/6mov2fWTD6ZiT2+FC62b2Mczw=
 github.com/giantswarm/apiextensions v0.2.3 h1:101b83FllHYgKP69LbmG3YOU+nL6jBHn/wL3KXZPNDs=
 github.com/giantswarm/apiextensions v0.2.3/go.mod h1:sdtmW67L+Y+jgF//ra4jbOI238SrPtfGHtckCRyw4Ak=
+github.com/giantswarm/appcatalog v0.1.11 h1:VM1fOBBVDSn23nbzTr6W4POC3c/6O9xm0pUUTr1XRI0=
+github.com/giantswarm/appcatalog v0.1.11/go.mod h1:jxC7n+2+TP/ub8kmbIZQ+qcVM55LixRhPP+KznTbKnQ=
 github.com/giantswarm/apprclient v0.2.0 h1:XLi/xt2BE316zCjgG9sJF25gKfIkIkdxPzgWmR8pACI=
 github.com/giantswarm/apprclient v0.2.0/go.mod h1:iAGOReCnEud0xxwhDS/lI50JSUN4zRCB3vlPRqH3IVc=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
-github.com/giantswarm/e2e-harness v0.2.0 h1:M71fV6T3zIjpg63eAbP8d5eHxCLLT4Q6hskiWelw6jM=
-github.com/giantswarm/e2e-harness v0.2.0/go.mod h1:+2H1VF3hRA75LQHVYno0/GmWxA/f7YEc9Bey03jyGRY=
 github.com/giantswarm/e2esetup v0.2.0 h1:hx6Fpt+8bn18Sfep8pU5oWASBPdp93trys1UbMcORGk=
 github.com/giantswarm/e2esetup v0.2.0/go.mod h1:4zjZ0u/Se1rPF/J2kVfaa0QiEW6Zi1cWp689wvXjyeU=
 github.com/giantswarm/errors v0.2.0 h1:l9bAe0IQBHLkZQVT+h79DTCJQ3tuDFrOfUySVlbKn10=
@@ -226,6 +226,7 @@ github.com/giantswarm/k8sportforward v0.2.0 h1:nzyKUtSWEbayvF74u3Pkr8AKKa3rk6Lcc
 github.com/giantswarm/k8sportforward v0.2.0/go.mod h1:+hyTTG0V2f3V28hDyEhJZQ341LTgSeXCgcZO2AeqLlI=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=
 github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8To8vXmT5VCg24RDg=
+github.com/giantswarm/microerror v0.0.0-20191011121515-e0ebc4ecf5a5/go.mod h1://Lo9dKJ8P2TBciuky5fDHEItccyvZOWE+B/0JiJT8A=
 github.com/giantswarm/microerror v0.2.0 h1:SaE7S34mp/wEiQkgtPiq8wQbNUTCj1gjiCWPjO3wgJo=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
 github.com/giantswarm/microkit v0.2.0 h1:5bHoK8t3d8D6IcUOqErkuCzZhLQyRMcxOVLF+jqCLc4=
@@ -505,6 +506,7 @@ github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/juju/errgo v0.0.0-20140925100237-08cceb5d0b53/go.mod h1:ZtgUe3RyZisw/AlQjgU9DeO3hqUH9E/bkreI2FLg/QY=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/integration/key/catalog.go
+++ b/integration/key/catalog.go
@@ -1,0 +1,9 @@
+package key
+
+func DefaultCatalogStorageURL() string {
+	return "https://giantswarm.github.io/default-catalog"
+}
+
+func DefaultTestCatalogStorageURL() string {
+	return "https://giantswarm.github.io/default-test-catalog"
+}

--- a/integration/key/namespace.go
+++ b/integration/key/namespace.go
@@ -1,0 +1,5 @@
+package key
+
+func Namespace() string {
+	return "giantswarm"
+}

--- a/integration/key/release_name.go
+++ b/integration/key/release_name.go
@@ -1,6 +1,6 @@
 package key
 
-func ChartOperatorReleaseName() string {
+func ReleaseName() string {
 	return "chart-operator"
 }
 

--- a/integration/release/error.go
+++ b/integration/release/error.go
@@ -1,0 +1,32 @@
+package release
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var releaseStatusNotMatchingError = &microerror.Error{
+	Kind: "releaseStatusNotMatchingError",
+}
+
+// IsReleaseStatusNotMatching asserts releaseStatusNotMatchingError
+func IsReleaseStatusNotMatching(err error) bool {
+	return microerror.Cause(err) == releaseStatusNotMatchingError
+}
+
+var releaseVersionNotMatchingError = &microerror.Error{
+	Kind: "releaseVersionNotMatchingError",
+}
+
+// IsReleaseVersionNotMatching asserts releaseVersionNotMatchingError
+func IsReleaseVersionNotMatching(err error) bool {
+	return microerror.Cause(err) == releaseVersionNotMatchingError
+}

--- a/integration/release/release.go
+++ b/integration/release/release.go
@@ -1,0 +1,89 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/helmclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+type Config struct {
+	HelmClient *helmclient.Client
+	Logger     micrologger.Logger
+}
+
+type Release struct {
+	helmClient *helmclient.Client
+	logger     micrologger.Logger
+}
+
+func New(config Config) (*Release, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.HelmClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HelmClient must not be empty", config)
+	}
+
+	r := &Release{
+		helmClient: config.HelmClient,
+		logger:     config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Release) WaitForChartInfo(ctx context.Context, release, version string) error {
+	operation := func() error {
+		rh, err := r.helmClient.GetReleaseHistory(ctx, release)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		if rh.Version != version {
+			return microerror.Maskf(releaseVersionNotMatchingError, "waiting for '%s', current '%s'", version, rh.Version)
+		}
+		return nil
+	}
+
+	notify := func(err error, t time.Duration) {
+		r.logger.Log("level", "debug", "message", fmt.Sprintf("failed to get release version '%s': retrying in %s", version, t), "stack", fmt.Sprintf("%v", err))
+	}
+
+	b := backoff.NewExponential(backoff.ShortMaxWait, backoff.LongMaxInterval)
+	err := backoff.RetryNotify(operation, b, notify)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	return nil
+}
+
+func (r *Release) WaitForStatus(ctx context.Context, release, status string) error {
+	operation := func() error {
+		rc, err := r.helmClient.GetReleaseContent(ctx, release)
+		if helmclient.IsReleaseNotFound(err) && status == "DELETED" {
+			// Error is expected because we purge releases when deleting.
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		if rc.Status != status {
+			return microerror.Maskf(releaseStatusNotMatchingError, "waiting for '%s', current '%s'", status, rc.Status)
+		}
+		return nil
+	}
+
+	notify := func(err error, t time.Duration) {
+		r.logger.Log("level", "debug", "message", fmt.Sprintf("failed to get release status '%s': retrying in %s", status, t), "stack", fmt.Sprintf("%v", err))
+	}
+
+	b := backoff.NewExponential(backoff.MediumMaxWait, backoff.LongMaxInterval)
+	err := backoff.RetryNotify(operation, b, notify)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	return nil
+}

--- a/integration/setup/config.go
+++ b/integration/setup/config.go
@@ -1,17 +1,14 @@
 package setup
 
 import (
-	"github.com/giantswarm/e2e-harness/pkg/release"
 	"github.com/giantswarm/e2esetup/chart/env"
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-)
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-const (
-	namespace       = "giantswarm"
-	tillerNamespace = "kube-system"
+	"github.com/giantswarm/chart-operator/integration/release"
 )
 
 type Config struct {
@@ -68,7 +65,7 @@ func NewConfig() (Config, error) {
 			Logger:               logger,
 			K8sClient:            cpK8sClients.K8sClient(),
 			RestConfig:           cpK8sClients.RESTConfig(),
-			TillerNamespace:      tillerNamespace,
+			TillerNamespace:      metav1.NamespaceSystem,
 			TillerUpgradeEnabled: true,
 		}
 		helmClient, err = helmclient.New(c)
@@ -80,13 +77,8 @@ func NewConfig() (Config, error) {
 	var newRelease *release.Release
 	{
 		c := release.Config{
-			ExtClient:  cpK8sClients.ExtClient(),
-			G8sClient:  cpK8sClients.G8sClient(),
 			HelmClient: helmClient,
-			K8sClient:  cpK8sClients.K8sClient(),
 			Logger:     logger,
-
-			Namespace: namespace,
 		}
 
 		newRelease, err = release.New(c)

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -7,14 +7,18 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
-	"github.com/giantswarm/e2e-harness/pkg/release"
+	"github.com/giantswarm/appcatalog"
+	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
+	"github.com/spf13/afero"
+	"k8s.io/helm/pkg/helm"
 
-	"github.com/giantswarm/chart-operator/integration/env"
 	"github.com/giantswarm/chart-operator/integration/key"
 	"github.com/giantswarm/chart-operator/integration/templates"
+	"github.com/giantswarm/chart-operator/pkg/project"
 )
 
 func Setup(m *testing.M, config Config) {
@@ -40,24 +44,81 @@ func installResources(ctx context.Context, config Config) error {
 	var err error
 
 	{
-		err := config.K8s.EnsureNamespaceCreated(ctx, namespace)
+		err = config.K8s.EnsureNamespaceCreated(ctx, key.Namespace())
 		if err != nil {
 			return microerror.Mask(err)
 		}
 	}
 
+	var latestOperatorRelease string
 	{
-		err = config.HelmClient.EnsureTillerInstalled(ctx)
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("getting latest %#q release", project.Name()))
+
+		latestOperatorRelease, err = appcatalog.GetLatestVersion(ctx, key.DefaultCatalogStorageURL(), project.Name())
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("latest %#q release is %#q", project.Name(), latestOperatorRelease))
+	}
+
+	var operatorTarballPath string
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "getting tarball URL")
+
+		operatorVersion := fmt.Sprintf("%s-%s", latestOperatorRelease, project.Version())
+		operatorTarballURL, err := appcatalog.NewTarballURL(key.DefaultTestCatalogStorageURL(), project.Name(), operatorVersion)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tarball URL is %#q", operatorTarballURL))
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "pulling tarball")
+
+		operatorTarballPath, err = config.HelmClient.PullChartTarball(ctx, operatorTarballURL)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tarball path is %#q", operatorTarballPath))
 	}
 
 	{
-		err = config.Release.InstallOperator(ctx, key.ChartOperatorReleaseName(), release.NewVersion(env.CircleSHA()), templates.ChartOperatorValues, v1alpha1.NewChartCRD())
+		defer func() {
+			fs := afero.NewOsFs()
+			err := fs.Remove(operatorTarballPath)
+			if err != nil {
+				config.Logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %#q failed", operatorTarballPath), "stack", fmt.Sprintf("%#v", err))
+			}
+		}()
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installing %#q", project.Name()))
+
+		err = config.HelmClient.InstallReleaseFromTarball(ctx,
+			operatorTarballPath,
+			key.Namespace(),
+			helm.ReleaseName(key.ReleaseName()),
+			helm.ValueOverrides([]byte(templates.ChartOperatorValues)),
+			helm.InstallWait(true))
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installed %#q", project.Name()))
+	}
+
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring chart CRD exists")
+
+		// The operator will install the CRD on boot but we create chart CRs
+		// in the tests so this ensures the CRD is present.
+		err = config.K8sClients.CRDClient().EnsureCreated(ctx, v1alpha1.NewChartCRD(), backoff.NewMaxRetries(7, 1*time.Second))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensured chart CRD exists")
 	}
 
 	return nil

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/afero"
 	"k8s.io/helm/pkg/helm"
 
+	"github.com/giantswarm/chart-operator/integration/env"
 	"github.com/giantswarm/chart-operator/integration/key"
 	"github.com/giantswarm/chart-operator/integration/templates"
 	"github.com/giantswarm/chart-operator/pkg/project"
@@ -66,7 +67,7 @@ func installResources(ctx context.Context, config Config) error {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "getting tarball URL")
 
-		operatorVersion := fmt.Sprintf("%s-%s", latestOperatorRelease, project.Version())
+		operatorVersion := fmt.Sprintf("%s-%s", latestOperatorRelease, env.CircleSHA())
 		operatorTarballURL, err := appcatalog.NewTarballURL(key.DefaultTestCatalogStorageURL(), project.Name(), operatorVersion)
 		if err != nil {
 			return microerror.Mask(err)

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -51,6 +51,13 @@ func installResources(ctx context.Context, config Config) error {
 		}
 	}
 
+	{
+		err = config.HelmClient.EnsureTillerInstalled(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	var latestOperatorRelease string
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("getting latest %#q release", project.Name()))

--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -6,7 +6,7 @@ package templates
 const ChartOperatorValues = `cnr:
   address: http://cnr-server:5000
 clusterDNSIP: 10.96.0.10
-e2e: true
+e2e: false
 
 Installation:
   V1:


### PR DESCRIPTION
This is needed for the flattening. So that we install chart-operator from the default catalog and not appr.

We already removed e2e-harness from the helm3 branch in https://github.com/giantswarm/chart-operator/pull/376. This gets the master branch in sync.
