### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ We check progress in the next reconciliation loop. ([#362](https://github.com/gi
 - Security context in deployment spec with non-root user.
 
 [Unreleased]: https://github.com/giantswarm/chart-operator/compare/v0.13.0..HEAD
+[v0.13.0]: https://github.com/giantswarm/chart-operator/releases/tag/v0.13.0
 [v0.12.4]: https://github.com/giantswarm/chart-operator/releases/tag/v0.12.4
 [v0.12.3]: https://github.com/giantswarm/chart-operator/releases/tag/v0.12.3
 [v0.12.2]: https://github.com/giantswarm/chart-operator/releases/tag/v0.12.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## [v0.13.0] 2020-04-21
+
 ### Changed
 
 - Deploy as a unique app in app collection in control plane clusters.
@@ -74,7 +76,10 @@ We check progress in the next reconciliation loop. ([#362](https://github.com/gi
 - Separate podsecuritypolicy.
 - Security context in deployment spec with non-root user.
 
-[Unreleased]: https://github.com/giantswarm/chart-operator/compare/v0.12.1..HEAD
+[Unreleased]: https://github.com/giantswarm/chart-operator/compare/v0.13.0..HEAD
+[v0.12.4]: https://github.com/giantswarm/chart-operator/releases/tag/v0.12.4
+[v0.12.3]: https://github.com/giantswarm/chart-operator/releases/tag/v0.12.3
+[v0.12.2]: https://github.com/giantswarm/chart-operator/releases/tag/v0.12.2
 [v0.12.1]: https://github.com/giantswarm/chart-operator/releases/tag/v0.12.1
 [v0.12.0]: https://github.com/giantswarm/chart-operator/releases/tag/v0.12.0
 [v0.8.0]: https://github.com/giantswarm/chart-operator/releases/tag/v0.8.0

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	name        = "chart-operator"
 	gitSHA      = "n/a"
 	source      = "https://github.com/giantswarm/chart-operator"
-	version     = "0.12.5-dev"
+	version     = "0.13.0"
 )
 
 // ChartVersion is fixed for chart CRs. This is because they exist in both

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -9,10 +9,10 @@ func NewVersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "chart-operator",
-				Description: "Only update failed Helm releases if the chart values or version has changed.",
+				Description: "Deploy as a unique app in control plane clusters.",
 				Kind:        versionbundle.KindAdded,
 				URLs: []string{
-					"https://github.com/giantswarm/chart-operator/pull/422",
+					"https://github.com/giantswarm/chart-operator/pull/421",
 				},
 			},
 		},


### PR DESCRIPTION
Going with 0.13.0 for the first release as a unique app.

We need a way to identify if chart-operator uses Helm 3 or Helm 2. So 1.0.0 will be the first Helm 3 release. This is the next planned release unless there are any urgent bug fixes.
