### PR TITLE
helm3; update to 1.0.0

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "chart-operator"
 	source      = "https://github.com/giantswarm/chart-operator"
-	version     = "0.13.1-dev"
+	version     = "1.0.0-dev"
 )
 
 // ChartVersion is fixed for chart CRs. This is because they exist in both


### PR DESCRIPTION
For helm3 supported version operators; we should know that having a major version as 1 means it could process helm release as helm3 protocol.