### PR TITLE
helm3: Always push to aliyun

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,6 @@ workflows:
           requires:
             - go-build
           filters:
-            branches:
-              only: master
             # Trigger the job also on git tag.
             tags:
               only: /^v.*/


### PR DESCRIPTION
I hit this when testing on giraffe. We should always push the image not just on merge to master.