### PR TITLE
Fixing empty lastDeployed when release deployment is not successful 

### DIFF
--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -41,7 +41,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			status := v1alpha1.ChartStatus{
 				Reason: cc.Status.Reason,
 				Release: v1alpha1.ChartStatusRelease{
-					Status: cc.Status.Release.Status,
+					LastDeployed: metav1.Time{},
+					Status:       cc.Status.Release.Status,
 				},
 			}
 


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/10644

Filling empty deployment timestamp in case of deployment failure. 