### PR TITLE
Disable pushing to app collections during Helm 3 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,47 +67,48 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-chart-operator-to-aws-app-collection
-          app_name: "chart-operator"
-          app_collection_repo: "aws-app-collection"
-          unique: "true"
-          requires:
-            - push-chart-operator-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+      # TODO: Uncomment it after we deployed helm 3 supported app-operator into all installations.
+      # - architect/push-to-app-collection:
+      #     context: architect
+      #     name: push-chart-operator-to-aws-app-collection
+      #     app_name: "chart-operator"
+      #     app_collection_repo: "aws-app-collection"
+      #     unique: "true"
+      #     requires:
+      #       - push-chart-operator-to-control-plane-app-catalog
+      #     filters:
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /^v.*/
 
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-chart-operator-to-azure-app-collection
-          app_name: "chart-operator"
-          app_collection_repo: "azure-app-collection"
-          unique: "true"
-          requires:
-            - push-chart-operator-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+      # - architect/push-to-app-collection:
+      #     context: architect
+      #     name: push-chart-operator-to-azure-app-collection
+      #     app_name: "chart-operator"
+      #     app_collection_repo: "azure-app-collection"
+      #     unique: "true"
+      #     requires:
+      #       - push-chart-operator-to-control-plane-app-catalog
+      #     filters:
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /^v.*/
 
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-chart-operator-to-kvm-app-collection
-          app_name: "chart-operator"
-          app_collection_repo: "kvm-app-collection"
-          unique: "true"
-          requires:
-            - push-chart-operator-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+      # - architect/push-to-app-collection:
+      #     context: architect
+      #     name: push-chart-operator-to-kvm-app-collection
+      #     app_name: "chart-operator"
+      #     app_collection_repo: "kvm-app-collection"
+      #     unique: "true"
+      #     requires:
+      #       - push-chart-operator-to-control-plane-app-catalog
+      #     filters:
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /^v.*/
 
       - architect/integration-test:
           context: architect


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10973

It will be reenabled once all control planes have been upgraded to Helm 3.
