### PR TITLE
version upgrade to 1.0.1-dev

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "chart-operator"
 	source      = "https://github.com/giantswarm/chart-operator"
-	version     = "1.0.0"
+	version     = "1.0.1-dev"
 )
 
 // ChartVersion is fixed for chart CRs. This is because they exist in both


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/10973

Since 1.0.0 chart-operator is released, we upgrade the `project.go` file accordingly. 