### PR TITLE
Canceling release resource if helm 2 release is not deleted

### DIFF
--- a/service/controller/chart/resource/release/create_test.go
+++ b/service/controller/chart/resource/release/create_test.go
@@ -75,6 +75,8 @@ func Test_Resource_Release_newCreate(t *testing.T) {
 			HelmClient: helmclienttest.New(helmclienttest.Config{}),
 			K8sClient:  k8sfake.NewSimpleClientset(),
 			Logger:     microloggertest.New(),
+
+			TillerNamespace: "giantswarm",
 		}
 
 		newResource, err = New(c)

--- a/service/controller/chart/resource/release/current.go
+++ b/service/controller/chart/resource/release/current.go
@@ -36,7 +36,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	if hasConfigmap {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q has been not migrated from helm 2", key.ReleaseName(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q has not been migrated from helm 2", key.ReleaseName(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		resourcecanceledcontext.SetCanceled(ctx)
 		return nil, nil

--- a/service/controller/chart/resource/release/current.go
+++ b/service/controller/chart/resource/release/current.go
@@ -30,6 +30,18 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, nil
 	}
 
+	hasConfigmap, err := r.findHelmV2ConfigMaps(ctx, key.ReleaseName(cr))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if hasConfigmap {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q has been not migrated from helm 2", key.ReleaseName(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	}
+
 	releaseName := key.ReleaseName(cr)
 	releaseContent, err := r.helmClient.GetReleaseContent(ctx, key.Namespace(cr), releaseName)
 	if helmclient.IsReleaseNotFound(err) {

--- a/service/controller/chart/resource/release/current_test.go
+++ b/service/controller/chart/resource/release/current_test.go
@@ -145,6 +145,8 @@ func Test_CurrentState(t *testing.T) {
 				HelmClient: helmClient,
 				K8sClient:  k8sfake.NewSimpleClientset(),
 				Logger:     microloggertest.New(),
+
+				TillerNamespace: "giantswarm",
 			}
 
 			r, err := New(c)

--- a/service/controller/chart/resource/release/delete_test.go
+++ b/service/controller/chart/resource/release/delete_test.go
@@ -77,6 +77,8 @@ func Test_Resource_Release_newDeleteChange(t *testing.T) {
 			HelmClient: helmclienttest.New(helmclienttest.Config{}),
 			K8sClient:  k8sfake.NewSimpleClientset(),
 			Logger:     microloggertest.New(),
+
+			TillerNamespace: "giantswarm",
 		}
 
 		newResource, err = New(c)

--- a/service/controller/chart/resource/release/desired_test.go
+++ b/service/controller/chart/resource/release/desired_test.go
@@ -328,6 +328,8 @@ func Test_DesiredState(t *testing.T) {
 				HelmClient: helmclienttest.New(helmclienttest.Config{}),
 				K8sClient:  k8sfake.NewSimpleClientset(objs...),
 				Logger:     microloggertest.New(),
+
+				TillerNamespace: "giantswarm",
 			}
 			r, err := New(c)
 			if err != nil {

--- a/service/controller/chart/resource/release/resource.go
+++ b/service/controller/chart/resource/release/resource.go
@@ -108,7 +108,7 @@ func (r *Resource) findHelmV2ConfigMaps(ctx context.Context, releaseName string)
 		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", "NAME", releaseName, "OWNER", "TILLER"),
 	}
 
-	// Check whether it keep helm2 release configMaps
+	// Check whether there are still helm2 release configmaps.
 	cms, err := r.k8sClient.CoreV1().ConfigMaps(r.tillerNamespace).List(lo)
 	if err != nil {
 		return false, microerror.Mask(err)

--- a/service/controller/chart/resource/release/resource.go
+++ b/service/controller/chart/resource/release/resource.go
@@ -42,6 +42,9 @@ type Config struct {
 	HelmClient helmclient.Interface
 	K8sClient  kubernetes.Interface
 	Logger     micrologger.Logger
+
+	// Settings.
+	TillerNamespace string
 }
 
 // Resource implements the chart resource.
@@ -52,6 +55,9 @@ type Resource struct {
 	helmClient helmclient.Interface
 	k8sClient  kubernetes.Interface
 	logger     micrologger.Logger
+
+	// Settings.
+	tillerNamespace string
 }
 
 // New creates a new configured chart resource.
@@ -73,6 +79,11 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	// Settings.
+	if config.TillerNamespace == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TillerNamespace must not be empty", config)
+	}
+
 	r := &Resource{
 		// Dependencies.
 		fs:         config.Fs,
@@ -80,6 +91,9 @@ func New(config Config) (*Resource, error) {
 		helmClient: config.HelmClient,
 		k8sClient:  config.K8sClient,
 		logger:     config.Logger,
+
+		// Settings.
+		tillerNamespace: config.TillerNamespace,
 	}
 
 	return r, nil
@@ -87,6 +101,20 @@ func New(config Config) (*Resource, error) {
 
 func (r *Resource) Name() string {
 	return Name
+}
+
+func (r *Resource) findHelmV2ConfigMaps(ctx context.Context, releaseName string) (bool, error) {
+	lo := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", "NAME", releaseName, "OWNER", "TILLER"),
+	}
+
+	// Check whether it keep helm2 release configMaps
+	cms, err := r.k8sClient.CoreV1().ConfigMaps(r.tillerNamespace).List(lo)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return len(cms.Items) > 0, nil
 }
 
 // patchAnnotations updates the chart CR annotations if they have changed.

--- a/service/controller/chart/resource/release/update_test.go
+++ b/service/controller/chart/resource/release/update_test.go
@@ -152,6 +152,8 @@ func Test_Resource_Release_newUpdateChange(t *testing.T) {
 			HelmClient: helmclienttest.New(helmclienttest.Config{}),
 			K8sClient:  k8sfake.NewSimpleClientset(),
 			Logger:     microloggertest.New(),
+
+			TillerNamespace: "giantswarm",
 		}
 
 		newResource, err = New(c)

--- a/service/controller/chart/resource_set.go
+++ b/service/controller/chart/resource_set.go
@@ -82,6 +82,9 @@ func newChartResourceSet(config chartResourceSetConfig) (*controller.ResourceSet
 			HelmClient: config.HelmClient,
 			K8sClient:  config.K8sClient,
 			Logger:     config.Logger,
+
+			// Settings
+			TillerNamespace: config.TillerNamespace,
 		}
 
 		ops, err := release.New(c)


### PR DESCRIPTION
Following https://github.com/giantswarm/giantswarm/issues/10973#issuecomment-634473564 

chart-operator is creating helm 3 release even before app-operator starts cordon all charts and start the migration. 

This patch would prevent that early behavior.