### PR TITLE
Fixing Cluster role binding metadata name

### DIFF
--- a/helm/chart-operator/templates/rbac.yaml
+++ b/helm/chart-operator/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
+  name: {{ tpl .Values.resource.default.name  . }}-cluster-admin
   labels:
     {{- include "chart-operator.labels" . | nindent 4 }}
 subjects:


### PR DESCRIPTION
Since helm-2to3-migration issues, We need to turn off helm-force annotation from each App CRs.
After removing the helm-force annotation, I found below error from the chart-operator upgrading. 

```
  version: 1.0.1-b2f75df3d74d8b8291f945358d38d279a7452dc1
status:
  appVersion: 1.0.2-dev
  reason: 'Upgrade "chart-operator-unique" failed: ClusterRoleBinding.rbac.authorization.k8s.io
    "chart-operator-unique" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:"rbac.authorization.k8s.io",
    Kind:"ClusterRole", Name:"cluster-admin"}: cannot change roleRef'
```

Since ClusterRoleBinding object is immutable, we need to create another object in case of changing the `RoleRef` value.