### PR TITLE
Update apiextentions as 0.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/giantswarm/chart-operator
 go 1.14
 
 require (
-	github.com/giantswarm/apiextensions v0.4.3
+	github.com/giantswarm/apiextensions v0.4.4
 	github.com/giantswarm/appcatalog v0.2.3
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/e2esetup v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/giantswarm/apiextensions v0.2.0/go.mod h1:iw66G0WDcrQl9mi2m/6mov2fWTD6ZiT2+FC62b2Mczw=
-github.com/giantswarm/apiextensions v0.4.3 h1:jnNsdeB+qstzsJ04hU0AOP1NM+GnNVIevnOakGeZY0Q=
-github.com/giantswarm/apiextensions v0.4.3/go.mod h1:iMZLjyvqRIVPTAQGbjwTSqifwrGB41a4mW8MwC45mYI=
+github.com/giantswarm/apiextensions v0.4.4 h1:yqxNdcsA0DT0+aUeeAN6R2RrX4LTsBdQ6k4S4AdgBy4=
+github.com/giantswarm/apiextensions v0.4.4/go.mod h1:iMZLjyvqRIVPTAQGbjwTSqifwrGB41a4mW8MwC45mYI=
 github.com/giantswarm/appcatalog v0.2.3 h1:3zU0bLBdULmfVZ9Lnu4CUUMtpjc4uD5WGwV3ntqSy/I=
 github.com/giantswarm/appcatalog v0.2.3/go.mod h1:jxC7n+2+TP/ub8kmbIZQ+qcVM55LixRhPP+KznTbKnQ=
 github.com/giantswarm/apprclient v0.2.0/go.mod h1:iAGOReCnEud0xxwhDS/lI50JSUN4zRCB3vlPRqH3IVc=


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/11261

After apiextensions 0.4.4, `lastDeployed` could be assigned as null values.