### PR TITLE
Disable force upgrade from helm 3

### DIFF
--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -32,6 +32,10 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	upgradeForce := key.HasForceUpgradeAnnotation(cr)
 
 	if releaseState.Name != "" {
+		// TODO: Disabling upgrade-force from chart-operator 1.0.2
+		//
+		//	See https://github.com/giantswarm/giantswarm/issues/11376
+		//
 		if upgradeForce {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q is disabled from helm upgrade-force  ", releaseState.Name))
 		}

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -37,7 +37,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		//	See https://github.com/giantswarm/giantswarm/issues/11376
 		//
 		if upgradeForce {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q is disabled from helm upgrade-force  ", releaseState.Name))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("disabling helm upgrade-force on release %#q", releaseState.Name))
 		}
 		// We set the checksum annotation so the update state calculation
 		// is accurate when we check in the next reconciliation loop.

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -37,7 +37,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		//	See https://github.com/giantswarm/giantswarm/issues/11376
 		//
 		if upgradeForce {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("disabling helm upgrade-force on release %#q", releaseState.Name))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm upgrade force is disabled for %#q", releaseState.Name))
 		}
 		// We set the checksum annotation so the update state calculation
 		// is accurate when we check in the next reconciliation loop.

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -32,8 +32,9 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	upgradeForce := key.HasForceUpgradeAnnotation(cr)
 
 	if releaseState.Name != "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release %#q with force == %t", releaseState.Name, upgradeForce))
-
+		if upgradeForce {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q is disabled from helm upgrade-force  ", releaseState.Name))
+		}
 		// We set the checksum annotation so the update state calculation
 		// is accurate when we check in the next reconciliation loop.
 		err = r.patchAnnotations(ctx, cr, releaseState)
@@ -88,7 +89,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		// We will check the progress in the next reconciliation loop.
 		go func() {
 			opts := helmclient.UpdateOptions{
-				Force: upgradeForce,
+				Force: false,
 			}
 
 			// We need to pass the ValueOverrides option to make the update process


### PR DESCRIPTION
Disabling force-upgrade from helm3 to mitigate errors from helmclient. 

For more about it, please read; https://github.com/helm/helm/issues/7956#issuecomment-632274443. 