### PR TITLE
Add policy apigroup into clusterrold

### DIFF
--- a/helm/chart-operator/templates/rbac.yaml
+++ b/helm/chart-operator/templates/rbac.yaml
@@ -22,6 +22,7 @@ metadata:
 rules:
   - apiGroups:
       - extensions
+      - policy
     resources:
       - podsecuritypolicies
     resourceNames:


### PR DESCRIPTION
To support k8s 1.16 and its lower version all together at the same time, we need to add `policy` into `podsecuritypolicies` resource's apiGroup. 
Otherwise, you will encounter with below message.
```
 helm3 --namespace giantswarm history chart-operator-unique -o yaml
- app_version: 1.0.2
  chart: chart-operator-1.0.2
  description: |-
    Release "chart-operator-unique" failed: clusterroles.rbac.authorization.k8s.io "chart-operator-unique-psp" is forbidden: user "system:serviceaccount:giantswarm:app-operator-unique" (groups=["system:serviceaccounts" "system:serviceaccounts:giantswarm" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
    {APIGroups:["extensions"], Resources:["podsecuritypolicies"], ResourceNames:["chart-operator-unique-psp"], Verbs:["use"]}
  revision: 1
  status: failed
  updated: "2020-06-09T20:15:05.5542656Z"
```