### PR TITLE
Upgrade Tiller image to 2.16.8

### DIFF
--- a/flag/service/helm/helm.go
+++ b/flag/service/helm/helm.go
@@ -6,5 +6,6 @@ import (
 
 type Helm struct {
 	HTTP            http.HTTP
+	TillerImageName string
 	TillerNamespace string
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/giantswarm/chart-operator
 
-go 1.13
+go 1.14
 
 require (
 	github.com/giantswarm/apiextensions v0.2.3

--- a/helm/chart-operator/templates/configmap.yaml
+++ b/helm/chart-operator/templates/configmap.yaml
@@ -16,11 +16,11 @@ data:
     service:
       helm:
         http:
-          {{ if (.Values.Installation) }}
+          {{- if (.Values.Installation) }}
           clientTimeout: '{{ .Values.Installation.V1.Helm.HTTP.ClientTimeout }}'
-          {{ else }}
+          {{- else }}
           clientTimeout: '{{ .Values.helm.http.clientTimeout }}'
-          {{ end }}
+          {{- end }}
         tillerImageName:  '{{ .Values.tiller.image }}'
         tillerNamespace:  '{{ .Values.tiller.namespace }}'
       image:

--- a/helm/chart-operator/templates/configmap.yaml
+++ b/helm/chart-operator/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
           {{ else }}
           clientTimeout: '{{ .Values.helm.http.clientTimeout }}'
           {{ end }}
+        tillerImageName:  '{{ .Values.tiller.image }}'
         tillerNamespace:  '{{ .Values.tiller.namespace }}'
       image:
         registry: '{{ .Values.image.registry }}'

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -45,6 +45,7 @@ resource:
     name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-psp'
 
 tiller:
+  image: "giantswarm/tiller:v2.16.8"
   namespace: "kube-system"
 
 cluster:

--- a/main.go
+++ b/main.go
@@ -107,7 +107,8 @@ func mainWithError() error {
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
 	daemonCommand.PersistentFlags().String(f.Service.Helm.HTTP.ClientTimeout, "5s", "HTTP timeout for pulling chart tarballs.")
-	daemonCommand.PersistentFlags().String(f.Service.Helm.TillerNamespace, "giantswarm", "Namespace for the Tiller pod.")
+	daemonCommand.PersistentFlags().String(f.Service.Helm.TillerImageName, "", "Image name for the Tiller deploy.")
+	daemonCommand.PersistentFlags().String(f.Service.Helm.TillerNamespace, "giantswarm", "Namespace for the Tiller deploy.")
 	daemonCommand.PersistentFlags().String(f.Service.Image.Registry, "quay.io", "Container image registry.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, false, "Whether to use the in-cluster config to authenticate with Kubernetes.")

--- a/service/service.go
+++ b/service/service.go
@@ -111,6 +111,7 @@ func New(config Config) (*Service, error) {
 			EnsureTillerInstalledMaxWait: 30 * time.Second,
 			HTTPClientTimeout:            config.Viper.GetDuration(config.Flag.Service.Helm.HTTP.ClientTimeout),
 			RestConfig:                   restConfig,
+			TillerImageName:              config.Viper.GetString(config.Flag.Service.Helm.TillerImageName),
 			TillerImageRegistry:          config.Viper.GetString(config.Flag.Service.Image.Registry),
 			TillerNamespace:              config.Viper.GetString(config.Flag.Service.Helm.TillerNamespace),
 			TillerUpgradeEnabled:         true,


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/11510

⚠️ We must deploy app-operator https://github.com/giantswarm/app-operator/pull/367 first, 
otherwise two operators would fight over image version of tiller deploy. 

Upgrading tiller to 2.16.8 and add new flag `TillerImageName` for more usability. 