### PR TITLE
Update chart CR status in case of migration not had been done

### DIFF
--- a/service/controller/chart/resource/release/current.go
+++ b/service/controller/chart/resource/release/current.go
@@ -32,6 +32,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	hasConfigmap, err := r.findHelmV2ConfigMaps(ctx, key.ReleaseName(cr))
 	if err != nil {
+		reason := fmt.Sprintf("release %#q didn't migrate to helm 3", key.ReleaseName(cr))
+		addStatusToContext(cc, reason, releaseNotInstalledStatus)
 		return nil, microerror.Mask(err)
 	}
 


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/11907

Updating chart CR status in case of migration had been not performed yet. 