### PR TITLE
Only update md5 hash after successful upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update MD5 Hash only if chart-operator upgrade the release successfully. 
+
 ## [v1.0.3] 2020-06-16
 
 ### Changed

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -31,136 +31,140 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 
 	upgradeForce := key.HasForceUpgradeAnnotation(cr)
 
-	if releaseState.Name != "" {
-		// TODO: Disabling upgrade-force from chart-operator 1.0.2
-		//
-		//	See https://github.com/giantswarm/giantswarm/issues/11376
-		//
-		if upgradeForce {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm upgrade force is disabled for %#q", releaseState.Name))
-		}
-		// We set the checksum annotation so the update state calculation
-		// is accurate when we check in the next reconciliation loop.
-		err = r.patchAnnotations(ctx, cr, releaseState)
+	if releaseState.Name == "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no release name is provided for %#q", cr.Name))
+		return nil
+	}
+
+	// TODO: Disabling upgrade-force from chart-operator 1.0.2
+	//
+	//	See https://github.com/giantswarm/giantswarm/issues/11376
+	//
+	if upgradeForce {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm upgrade force is disabled for %#q", releaseState.Name))
+	}
+
+	tarballURL := key.TarballURL(cr)
+	tarballPath, err := r.helmClient.PullChartTarball(ctx, tarballURL)
+	if helmclient.IsPullChartFailedError(err) {
+		reason := fmt.Sprintf("pulling chart %#q failed", tarballURL)
+		addStatusToContext(cc, reason, releaseNotInstalledStatus)
+
+		r.logger.LogCtx(ctx, "level", "warning", "message", reason, "stack", microerror.JSON(err))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if helmclient.IsPullChartNotFound(err) {
+		reason := fmt.Sprintf("chart %#q not found", tarballURL)
+		addStatusToContext(cc, reason, releaseNotInstalledStatus)
+
+		r.logger.LogCtx(ctx, "level", "warning", "message", reason, "stack", microerror.JSON(err))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if helmclient.IsPullChartTimeout(err) {
+		reason := fmt.Sprintf("timeout pulling %#q", tarballURL)
+		addStatusToContext(cc, reason, releaseNotInstalledStatus)
+
+		r.logger.LogCtx(ctx, "level", "warning", "message", reason, "stack", microerror.JSON(err))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	defer func() {
+		err := r.fs.Remove(tarballPath)
 		if err != nil {
-			return microerror.Mask(err)
+			r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %#q failed", tarballPath), "stack", fmt.Sprintf("%#v", err))
+		}
+	}()
+
+	ch := make(chan error)
+
+	// We update the helm release but with a short timeout so we don't
+	// block reconciling other CRs. This gives time to make the port
+	// forwarding connection to the Tiller API.
+	//
+	// If we do timeout the update will continue in the background.
+	// We will check the progress in the next reconciliation loop.
+	go func() {
+		opts := helmclient.UpdateOptions{
+			Force: false,
 		}
 
-		tarballURL := key.TarballURL(cr)
-		tarballPath, err := r.helmClient.PullChartTarball(ctx, tarballURL)
-		if helmclient.IsPullChartFailedError(err) {
-			reason := fmt.Sprintf("pulling chart %#q failed", tarballURL)
+		// We need to pass the ValueOverrides option to make the update process
+		// use the default values and prevent errors on nested values.
+		err = r.helmClient.UpdateReleaseFromTarball(ctx,
+			tarballPath,
+			key.Namespace(cr),
+			releaseState.Name,
+			releaseState.Values,
+			opts)
+		close(ch)
+	}()
+
+	select {
+	case <-ch:
+		// Fall through.
+	case <-time.After(3 * time.Second):
+		r.logger.LogCtx(ctx, "level", "debug", "message", "release still being updated")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
+	if helmclient.IsValidationFailedError(err) {
+		reason := err.Error()
+		reason = fmt.Sprintf("helm validation error: (%s)", reason)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q failed, %s", releaseState.Name, reason))
+		addStatusToContext(cc, reason, validationFailedStatus)
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if helmclient.IsInvalidManifest(err) {
+		reason := err.Error()
+		reason = fmt.Sprintf("invalid manifest error: (%s)", reason)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q failed, %s", releaseState.Name, reason))
+		addStatusToContext(cc, reason, invalidManifestStatus)
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if err != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q failed", releaseState.Name), "stack", microerror.JSON(err))
+
+		releaseContent, err := r.helmClient.GetReleaseContent(ctx, key.Namespace(cr), releaseState.Name)
+		if helmclient.IsReleaseNotFound(err) {
+			reason := fmt.Sprintf("release %#q not found", releaseState.Name)
 			addStatusToContext(cc, reason, releaseNotInstalledStatus)
 
 			r.logger.LogCtx(ctx, "level", "warning", "message", reason, "stack", microerror.JSON(err))
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			resourcecanceledcontext.SetCanceled(ctx)
 			return nil
-		} else if helmclient.IsPullChartNotFound(err) {
-			reason := fmt.Sprintf("chart %#q not found", tarballURL)
-			addStatusToContext(cc, reason, releaseNotInstalledStatus)
 
-			r.logger.LogCtx(ctx, "level", "warning", "message", reason, "stack", microerror.JSON(err))
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-			resourcecanceledcontext.SetCanceled(ctx)
-			return nil
-		} else if helmclient.IsPullChartTimeout(err) {
-			reason := fmt.Sprintf("timeout pulling %#q", tarballURL)
-			addStatusToContext(cc, reason, releaseNotInstalledStatus)
-
-			r.logger.LogCtx(ctx, "level", "warning", "message", reason, "stack", microerror.JSON(err))
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-			resourcecanceledcontext.SetCanceled(ctx)
-			return nil
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
-
-		defer func() {
-			err := r.fs.Remove(tarballPath)
-			if err != nil {
-				r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("deletion of %#q failed", tarballPath), "stack", fmt.Sprintf("%#v", err))
-			}
-		}()
-
-		ch := make(chan error)
-
-		// We update the helm release but with a short timeout so we don't
-		// block reconciling other CRs. This gives time to make the port
-		// forwarding connection to the Tiller API.
-		//
-		// If we do timeout the update will continue in the background.
-		// We will check the progress in the next reconciliation loop.
-		go func() {
-			opts := helmclient.UpdateOptions{
-				Force: false,
-			}
-
-			// We need to pass the ValueOverrides option to make the update process
-			// use the default values and prevent errors on nested values.
-			err = r.helmClient.UpdateReleaseFromTarball(ctx,
-				tarballPath,
-				key.Namespace(cr),
-				releaseState.Name,
-				releaseState.Values,
-				opts)
-			close(ch)
-		}()
-
-		select {
-		case <-ch:
-			// Fall through.
-		case <-time.After(3 * time.Second):
-			r.logger.LogCtx(ctx, "level", "debug", "message", "release still being updated")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-			return nil
-		}
-
-		if helmclient.IsValidationFailedError(err) {
-			reason := err.Error()
-			reason = fmt.Sprintf("helm validation error: (%s)", reason)
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q failed, %s", releaseState.Name, reason))
-			addStatusToContext(cc, reason, validationFailedStatus)
-
+		// Release is failed so the status resource will check the Helm release.
+		if releaseContent.Status == helmclient.StatusFailed {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to update release %#q", releaseContent.Name))
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			resourcecanceledcontext.SetCanceled(ctx)
 			return nil
-		} else if helmclient.IsInvalidManifest(err) {
-			reason := err.Error()
-			reason = fmt.Sprintf("invalid manifest error: (%s)", reason)
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q failed, %s", releaseState.Name, reason))
-			addStatusToContext(cc, reason, invalidManifestStatus)
-
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-			resourcecanceledcontext.SetCanceled(ctx)
-			return nil
-		} else if err != nil {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm release %#q failed", releaseState.Name), "stack", microerror.JSON(err))
-
-			releaseContent, err := r.helmClient.GetReleaseContent(ctx, key.Namespace(cr), releaseState.Name)
-			if helmclient.IsReleaseNotFound(err) {
-				reason := fmt.Sprintf("release %#q not found", releaseState.Name)
-				addStatusToContext(cc, reason, releaseNotInstalledStatus)
-
-				r.logger.LogCtx(ctx, "level", "warning", "message", reason, "stack", microerror.JSON(err))
-				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-				resourcecanceledcontext.SetCanceled(ctx)
-				return nil
-
-			} else if err != nil {
-				return microerror.Mask(err)
-			}
-			// Release is failed so the status resource will check the Helm release.
-			if releaseContent.Status == helmclient.StatusFailed {
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to update release %#q", releaseContent.Name))
-				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-				resourcecanceledcontext.SetCanceled(ctx)
-				return nil
-			}
-			return microerror.Mask(err)
 		}
+		return microerror.Mask(err)
+	}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated release %#q", releaseState.Name))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated release %#q", releaseState.Name))
+
+	// We set the checksum annotation so the update state calculation
+	// is accurate when we check in the next reconciliation loop.
+	err = r.patchAnnotations(ctx, cr, releaseState)
+	if err != nil {
+		return microerror.Mask(err)
 	}
 
 	return nil


### PR DESCRIPTION
chart-operator updates its hash value even though it failed to upgrade helm release. 

From `buffalo`, you can see chart-operator failed to upgrade `kvm-operator` in past reconciliation as below. 
```
D 07/02 10:32:34 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/kvm-operator-3.9.1-1 release.ApplyUpdateChange helm release `kvm-operator-3.9.1-1` failed, helm validation error: (error validating "": error validating data: [unknown object type "nil" in Service.metadata.labels.version, unknown object type "nil" in Service.spec.selector.version]) | chart-operator/service/controller/chart/resource/release/update.go:122 | controller=chart-operator-chart | event=update | loop=11 | version=115072389
```

But in next reconciliation, it found out it's not necessary to upgrade the release. 
```
D 07/02 10:33:28 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/kvm-operator-3.9.1-1 release.NewUpdatePatch finding out if the `kvm-operator-3.9.1-1` release has to be updated | chart-operator/service/controller/chart/resource/release/update.go:197 | controller=chart-operator-chart | event=update | loop=56 | version=115074459
D 07/02 10:33:28 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/kvm-operator-3.9.1-1 release.NewUpdatePatch the `kvm-operator-3.9.1-1` release does not have to be updated | chart-operator/service/controller/chart/resource/release/update.go:217 | controller=chart-operator-chart | event=update | loop=56 | version=115074459
```
