### PR TITLE
Set release revision in CR status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Update MD5 Hash only if chart-operator upgrade the release successfully. 
 - Make kubernetes wait timeout configurable when installing and updating
 releases.
+- Set release revision in CR status.
 
 ## [v1.0.3] 2020-06-16
 

--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -83,6 +83,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		Reason:     reason,
 		Release: v1alpha1.ChartStatusRelease{
 			LastDeployed: metav1.Time{Time: releaseContent.LastDeployed},
+			Revision:     releaseContent.Revision,
 			Status:       status,
 		},
 		Version: releaseContent.Version,


### PR DESCRIPTION
Towards giantswarm/giantswarm#11969


```bash
kg get chart prometheus-operator-app-unique -o yaml | yq .status.release
{
  "lastDeployed": "2020-07-07T08:55:00Z",
  "revision": 2,
  "status": "deployed"
}
```