### PR TITLE
Fix changelog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,17 +109,19 @@ We check progress in the next reconciliation loop. ([#362](https://github.com/gi
 - Separate podsecuritypolicy.
 - Security context in deployment spec with non-root user.
 
-[Unreleased]: https://github.com/giantswarm/chart-operator/compare/v1.0.3..HEAD
-[v1.0.3]: https://github.com/giantswarm/chart-operator/compare/v1.0.2..v1.0.3
-[v1.0.2]: https://github.com/giantswarm/chart-operator/compare/v1.0.1..v1.0.2
-[v1.0.1]: https://github.com/giantswarm/chart-operator/compare/v1.0.0..v1.0.1
-[v1.0.0]: https://github.com/giantswarm/chart-operator/compare/v0.13.0..v1.0.0
-[v0.13.0]: https://github.com/giantswarm/chart-operator/compare/v0.12.4..v0.13.0
-[v0.12.4]: https://github.com/giantswarm/chart-operator/compare/v0.12.3..v0.12.4
-[v0.12.3]: https://github.com/giantswarm/chart-operator/compare/v0.12.2..v0.12.3
-[v0.12.2]: https://github.com/giantswarm/chart-operator/compare/v0.12.1..v0.12.2
-[v0.12.1]: https://github.com/giantswarm/chart-operator/compare/v0.12.0..v0.12.1
-[v0.12.0]: https://github.com/giantswarm/chart-operator/compare/v0.8.0..v0.12.0
-[v0.8.0]: https://github.com/giantswarm/chart-operator/compare/v0.7.0..v0.8.0
+[Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/compare/v1.2.3...HEAD
+
+[Unreleased]: https://github.com/giantswarm/chart-operator/compare/v1.0.3...HEAD
+[v1.0.3]: https://github.com/giantswarm/chart-operator/compare/v1.0.2...v1.0.3
+[v1.0.2]: https://github.com/giantswarm/chart-operator/compare/v1.0.1...v1.0.2
+[v1.0.1]: https://github.com/giantswarm/chart-operator/compare/v1.0.0...v1.0.1
+[v1.0.0]: https://github.com/giantswarm/chart-operator/compare/v0.13.0...v1.0.0
+[v0.13.0]: https://github.com/giantswarm/chart-operator/compare/v0.12.4...v0.13.0
+[v0.12.4]: https://github.com/giantswarm/chart-operator/compare/v0.12.3...v0.12.4
+[v0.12.3]: https://github.com/giantswarm/chart-operator/compare/v0.12.2...v0.12.3
+[v0.12.2]: https://github.com/giantswarm/chart-operator/compare/v0.12.1...v0.12.2
+[v0.12.1]: https://github.com/giantswarm/chart-operator/compare/v0.12.0...v0.12.1
+[v0.12.0]: https://github.com/giantswarm/chart-operator/compare/v0.8.0...v0.12.0
+[v0.8.0]: https://github.com/giantswarm/chart-operator/compare/v0.7.0...v0.8.0
 
 [v0.7.0]: https://github.com/giantswarm/chart-operator/releases/tag/v0.7.0


### PR DESCRIPTION
For the new release automation its expecting 3 dots not 2 in changelog links.

https://github.com/giantswarm/architect/blob/b85a96fa76e666da98c0df9f68e874c9a8a09896/cmd/preparerelease/internal/modifier.go#L73-L77