### PR TITLE
Replace both # and / in branch labels

### DIFF
--- a/helm/chart-operator/templates/_helpers.tpl
+++ b/helm/chart-operator/templates/_helpers.tpl
@@ -19,7 +19,7 @@ Common labels
 {{- define "chart-operator.labels" -}}
 {{ include "chart-operator.selectorLabels" . }}
 app: {{ include "chart-operator.name" . | quote }}
-app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
+app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | replace "/" "-" | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
Towards giantswarm/giantswarm#12050

We use special characters in automation that break the integration tests because they are invalid in the branch label.

- `#` is used in the new release automation.
- `/` is used by dependabot in its PRs.


```
"stack":{"annotation":"NetworkPolicy.extensions \"chart-operator\" is invalid: metadata.labels: Invalid value: \"dependabot/go_modules/github.com/giantswarm/appcatalog-0.2.6\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```