### PR TITLE
Disable helm upgrade --force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Decrease CPU and memory requests.
+- Disable force upgrades since recreating resources is not supported.
 
 ## [1.0.5] - 2020-07-15
 

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -71,8 +71,15 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		}
 	}()
 
+	// TODO: Disabling helm upgrade --force from chart-operator since recreate
+	// is not supported.
+	//
+	//	See https://github.com/giantswarm/giantswarm/issues/11376
+	//
 	upgradeForce := key.HasForceUpgradeAnnotation(cr)
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release %#q with force == %t", releaseState.Name, upgradeForce))
+	if upgradeForce {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("helm upgrade force is disabled for %#q", releaseState.Name))
+	}
 
 	ch := make(chan error)
 
@@ -83,7 +90,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	// We will check the progress in the next reconciliation loop.
 	go func() {
 		opts := helmclient.UpdateOptions{
-			Force: upgradeForce,
+			Force: false,
 		}
 
 		// We need to pass the ValueOverrides option to make the update process


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11376

I enabled `helm upgrade --force` in chart-operator 1.0.5 but in its current state force is not usable for our use case. As we will get failed helm releases when chart-operator tries to update immutable fields.

In Helm 2 using force will also recreate. In Helm 3 force is available but recreating resources is not yet implemented. See https://github.com/helm/helm/issues/7082


