### PR TITLE
Quit reconciliation right after rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Updated backward incompatible Kubernetes dependencies to v1.18.5.
 - Updated Helm to v3.2.4.
+- Fix the rollback in a loop problem. 
 
 ## [1.0.7] - 2020-08-05
 

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -229,6 +229,8 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
+			// no-op after rollback
+			return nil, nil
 		}
 	}
 


### PR DESCRIPTION
Some helm releases got updated throttle if it stuck in `pending-upgrade` or `pending-rollback`. 
this is because the chart-operator has a bug to clear the annotation which related to the limit of retries. 

This PR would quit the reconciliation right after rollback so it would not clear the annotation just like now. 