### PR TITLE
Namespace resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Creating namespace before helm operations.
+
 ## [2.1.0] - 2020-08-18
 
 ## Changed

--- a/service/controller/chart/resource/namespace/create.go
+++ b/service/controller/chart/resource/namespace/create.go
@@ -49,7 +49,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if apierrors.IsAlreadyExists(err) {
-		// fall through
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created namespace %#q", key.Namespace(cr)))
 	} else if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/chart/resource/namespace/create.go
+++ b/service/controller/chart/resource/namespace/create.go
@@ -1,0 +1,60 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/giantswarm/apiextensions/v2/pkg/label"
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/chart-operator/v2/pkg/project"
+	"github.com/giantswarm/chart-operator/v2/service/controller/chart/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCustomResource(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: key.Namespace(cr),
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
+		},
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating namespace %#q", ns.Name))
+
+	ch := make(chan error)
+
+	go func() {
+		_, err = r.k8sClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+		close(ch)
+	}()
+
+	select {
+	case <-ch:
+		// Fall through.
+	case <-time.After(r.k8sWaitTimeout):
+		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout creating namespace %#q", key.Namespace(cr))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
+	if apierrors.IsAlreadyExists(err) {
+		// fall through
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created namespace %#q", key.Namespace(cr)))
+
+	return nil
+}

--- a/service/controller/chart/resource/namespace/create.go
+++ b/service/controller/chart/resource/namespace/create.go
@@ -43,7 +43,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	case <-ch:
 		// Fall through.
 	case <-time.After(r.k8sWaitTimeout):
-		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout creating namespace %#q", key.Namespace(cr))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("timeout creating namespace %#q", key.Namespace(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}

--- a/service/controller/chart/resource/namespace/delete.go
+++ b/service/controller/chart/resource/namespace/delete.go
@@ -1,0 +1,8 @@
+package namespace
+
+import "context"
+
+// EnsureDeleted is a no-op because the namespace for the app could be used for other apps, too.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/chart/resource/namespace/error.go
+++ b/service/controller/chart/resource/namespace/error.go
@@ -1,0 +1,12 @@
+package namespace
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/chart/resource/namespace/resource.go
+++ b/service/controller/chart/resource/namespace/resource.go
@@ -1,10 +1,11 @@
 package namespace
 
 import (
+	"time"
+
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/client-go/kubernetes"
-	"time"
 )
 
 const (

--- a/service/controller/chart/resource/namespace/resource.go
+++ b/service/controller/chart/resource/namespace/resource.go
@@ -1,0 +1,61 @@
+package namespace
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+	"time"
+)
+
+const (
+	Name = "namespace"
+
+	// defaultK8sWaitTimeout is how long to wait for the Kubernetes API when
+	// installing or updating a release before moving to process the next CR.
+	defaultK8sWaitTimeout = 10 * time.Second
+)
+
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+
+	// Settings.
+	K8sWaitTimeout time.Duration
+}
+
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+
+	// Settings.
+	k8sWaitTimeout time.Duration
+}
+
+// New creates a new configured tcnamespace resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	// Settings.
+	if config.K8sWaitTimeout == 0 {
+		config.K8sWaitTimeout = defaultK8sWaitTimeout
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r Resource) Name() string {
+	return Name
+}

--- a/service/controller/chart/resources.go
+++ b/service/controller/chart/resources.go
@@ -1,7 +1,6 @@
 package chart
 
 import (
-	"github.com/giantswarm/chart-operator/v2/service/controller/chart/resource/namespace"
 	"time"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
@@ -16,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/chart-operator/v2/service/controller/chart/resource/chartmigration"
+	"github.com/giantswarm/chart-operator/v2/service/controller/chart/resource/namespace"
 	"github.com/giantswarm/chart-operator/v2/service/controller/chart/resource/release"
 	"github.com/giantswarm/chart-operator/v2/service/controller/chart/resource/status"
 	"github.com/giantswarm/chart-operator/v2/service/controller/chart/resource/tillermigration"

--- a/service/controller/chart/resources.go
+++ b/service/controller/chart/resources.go
@@ -1,6 +1,7 @@
 package chart
 
 import (
+	"github.com/giantswarm/chart-operator/v2/service/controller/chart/resource/namespace"
 	"time"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
@@ -71,6 +72,21 @@ func newChartResources(config chartResourcesConfig) ([]resource.Interface, error
 		}
 	}
 
+	var namespaceResource resource.Interface
+	{
+		c := namespace.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			K8sWaitTimeout: config.K8sWaitTimeout,
+		}
+
+		namespaceResource, err = namespace.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var releaseResource resource.Interface
 	{
 		c := release.Config{
@@ -131,6 +147,7 @@ func newChartResources(config chartResourcesConfig) ([]resource.Interface, error
 	resources := []resource.Interface{
 		chartMigrationResource,
 		tillerMigrationResource,
+		namespaceResource,
 		releaseResource,
 		statusResource,
 	}


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/11748 
From helm3, it stops supporting to create new namespace from release creations. Therefore we need to create the namespace from the chart-operator if that namespace is not present in tenant clusters. 