### PR TITLE
Wiring timeout values for namespace resourceFix namespace resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Fixed the timeout value from namespace resource.
+- Fixed the timeout value for the namespace resource.
 
 ## [2.2.0] - 2020-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Fixed the timeout value from namespace resource.
+
 ## [2.2.0] - 2020-08-19
 
 ### Changed

--- a/service/controller/chart/resource/namespace/resource.go
+++ b/service/controller/chart/resource/namespace/resource.go
@@ -52,6 +52,8 @@ func New(config Config) (*Resource, error) {
 	r := &Resource{
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
+
+		k8sWaitTimeout: config.K8sWaitTimeout,
 	}
 
 	return r, nil


### PR DESCRIPTION
🐛 fix from the last release, Wiring timeout values for namespace resource. 