### PR TITLE
Adding logging for namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add monitoring labels
+- Add monitoring labels.
+
+### Changed
+
+- add namespace to logging message.
 
 ## [2.3.0] - 2020-08-24
 

--- a/service/controller/chart/resource/namespace/create.go
+++ b/service/controller/chart/resource/namespace/create.go
@@ -50,6 +50,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	if apierrors.IsAlreadyExists(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created namespace %#q", key.Namespace(cr)))
+		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/chart/resource/release/create.go
+++ b/service/controller/chart/resource/release/create.go
@@ -33,7 +33,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		return nil
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating release %#q", releaseState.Name))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating release %#q in namespace %#q", releaseState.Name, key.Namespace(cr)))
 
 	ns := key.Namespace(cr)
 	tarballURL := key.TarballURL(cr)
@@ -152,7 +152,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created release %#q", releaseState.Name))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created release %#q in namespace %#q", releaseState.Name, key.Namespace(cr)))
 
 	// We set the checksum annotation so the update state calculation
 	// is accurate when we check in the next reconciliation loop.

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -39,6 +39,8 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		return nil
 	}
 
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release %#q in namespace %#q", releaseState.Name, key.Namespace(cr)))
+
 	tarballURL := key.TarballURL(cr)
 	tarballPath, err := r.helmClient.PullChartTarball(ctx, tarballURL)
 	if helmclient.IsPullChartFailedError(err) {
@@ -171,7 +173,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated release %#q", releaseState.Name))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated release %#q in namespace %#q", releaseState.Name, key.Namespace(cr)))
 
 	// We set the checksum annotation so the update state calculation
 	// is accurate when we check in the next reconciliation loop.


### PR DESCRIPTION
During a conversation with @sslavic, We found out logging the namespace would help to understand the logic inside `release` resource. 