### PR TITLE
Remove memory limits from deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- add namespace to logging message.
+- Add namespace to logging message.
+
+### Fixed
+
+- Remove memory limits from deployment.
 
 ## [2.3.0] - 2020-08-24
 

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -106,5 +106,3 @@ spec:
           requests:
             cpu: 250m
             memory: 250Mi
-          limits:
-            memory: 250Mi


### PR DESCRIPTION
chart-operator has started OOMing in a few control planes. Removing memory limits so it can run.

https://gigantic.slack.com/archives/C03CPNRTS/p1599222623248300
