### PR TITLE
Only wait for push to Aliyun for AWS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,8 @@ workflows:
           app_collection_repo: "aws-app-collection"
           unique: "true"
           requires:
-            - push-chart-operator-to-control-plane-app-catalog
             - push-chart-operator-to-aliyun
+            - push-chart-operator-to-control-plane-app-catalog
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ workflows:
           chart: "chart-operator"
           requires:
             - push-chart-operator-to-quay
-            - push-chart-operator-to-aliyun
           filters:
             tags:
               only: /^v.*/
@@ -60,7 +59,6 @@ workflows:
           chart: "chart-operator"
           requires:
             - push-chart-operator-to-quay
-            - push-chart-operator-to-aliyun
           filters:
             tags:
               only: /^v.*/
@@ -73,6 +71,7 @@ workflows:
           unique: "true"
           requires:
             - push-chart-operator-to-control-plane-app-catalog
+            - push-chart-operator-to-aliyun
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Sometimes the push to Aliyun can be slow and delays the other steps. We only need to wait when pushing to the AWS app collection.