### PR TITLE
Refactor addAnnotation

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -19,10 +19,6 @@ const (
 	// force is used when upgrading the Helm release.
 	ForceHelmUpgrade = "chart-operator.giantswarm.io/force-helm-upgrade"
 
-	// UpgradeCount is the name of the annotation storing the number of
-	// rollbacks performed from the previous failed status.
-	UpgradeCount = "chart-operator.giantswarm.io/upgrade-count"
-
 	// RollbackCount is the name of the annotation storing the number of
 	// rollbacks performed from the previous pending status.
 	RollbackCount = "chart-operator.giantswarm.io/rollback-count"

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -19,6 +19,10 @@ const (
 	// force is used when upgrading the Helm release.
 	ForceHelmUpgrade = "chart-operator.giantswarm.io/force-helm-upgrade"
 
+	// UpgradeCount is the name of the annotation storing the number of
+	// rollbacks performed from the previous failed status.
+	UpgradeCount = "chart-operator.giantswarm.io/upgrade-count"
+
 	// RollbackCount is the name of the annotation storing the number of
 	// rollbacks performed from the previous pending status.
 	RollbackCount = "chart-operator.giantswarm.io/rollback-count"

--- a/service/controller/chart/resource/release/create.go
+++ b/service/controller/chart/resource/release/create.go
@@ -100,7 +100,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		// The install will continue in the background. We set the checksum
 		// annotation so the update state calculation is accurate when we check
 		// in the next reconciliation loop.
-		err = r.patchAnnotations(ctx, cr, releaseState)
+		err = r.addHashAnnotation(ctx, cr, releaseState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -156,7 +156,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 
 	// We set the checksum annotation so the update state calculation
 	// is accurate when we check in the next reconciliation loop.
-	err = r.patchAnnotations(ctx, cr, releaseState)
+	err = r.addHashAnnotation(ctx, cr, releaseState)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/chart/resource/release/create.go
+++ b/service/controller/chart/resource/release/create.go
@@ -97,9 +97,8 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	case <-time.After(r.k8sWaitTimeout):
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for %d secs. release still being created", int64(r.k8sWaitTimeout.Seconds())))
 
-		// The install will continue in the background. We set the checksum
-		// annotation so the update state calculation is accurate when we check
-		// in the next reconciliation loop.
+		// We set the hash annotation so the update state calculation is accurate
+		// when we check in the next reconciliation loop.
 		err = r.addHashAnnotation(ctx, cr, releaseState)
 		if err != nil {
 			return microerror.Mask(err)

--- a/service/controller/chart/resource/release/create.go
+++ b/service/controller/chart/resource/release/create.go
@@ -154,7 +154,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created release %#q in namespace %#q", releaseState.Name, key.Namespace(cr)))
 
-	// We set the checksum annotation so the update state calculation
+	// We set the hash annotation so the update state calculation
 	// is accurate when we check in the next reconciliation loop.
 	err = r.addHashAnnotation(ctx, cr, releaseState)
 	if err != nil {

--- a/service/controller/chart/resource/release/resource.go
+++ b/service/controller/chart/resource/release/resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/giantswarm/chart-operator/v2/pkg/annotation"
 	"strings"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/giantswarm/chart-operator/v2/pkg/annotation"
 	"github.com/giantswarm/chart-operator/v2/service/controller/chart/controllercontext"
 	"github.com/giantswarm/chart-operator/v2/service/controller/chart/key"
 )


### PR DESCRIPTION
We are using patch annotation in quite a few places. It makes sense to refactor it and use it in general. 

Skipping update changelog since it's refactoring. 