### PR TITLE
Stop updating revision in status in case of helm upgrade failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Stop repeating helm upgrade for the failed helm release.
+
 ## [2.3.4] - 2020-10-01
 
 ### Added

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -165,6 +165,8 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		}
 		// Release is failed so the status resource will check the Helm release.
 		if releaseContent.Status == helmclient.StatusFailed {
+			addStatusToContext(cc, releaseContent.Description, helmclient.StatusFailed)
+
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("failed to update release %#q", releaseContent.Name))
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			resourcecanceledcontext.SetCanceled(ctx)

--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -33,8 +33,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		status := v1alpha1.ChartStatus{
 			Reason: cc.Status.Reason,
 			Release: v1alpha1.ChartStatusRelease{
-				LastDeployed: metav1.Time{},
-				Status:       cc.Status.Release.Status,
+				Status: cc.Status.Release.Status,
 			},
 		}
 

--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -42,6 +42,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		return nil
 	}
 
 	releaseContent, err := r.helmClient.GetReleaseContent(ctx, key.Namespace(cr), releaseName)

--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -26,6 +26,24 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	releaseName := key.ReleaseName(cr)
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("getting status for release %#q", releaseName))
 
+	// If something goes wrong outside of Helm we add that to the
+	// controller context in the release resource. So we include this
+	// information in the CR status.
+	if cc.Status.Reason != "" {
+		status := v1alpha1.ChartStatus{
+			Reason: cc.Status.Reason,
+			Release: v1alpha1.ChartStatusRelease{
+				LastDeployed: metav1.Time{},
+				Status:       cc.Status.Release.Status,
+			},
+		}
+
+		err = r.setStatus(ctx, cr, status)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	releaseContent, err := r.helmClient.GetReleaseContent(ctx, key.Namespace(cr), releaseName)
 	if helmclient.IsReleaseNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q not found", releaseName))
@@ -34,24 +52,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		// something has gone wrong. This could be for a reason outside
 		// of Helm like the tarball URL is incorrect.
 		//
-		// If something goes wrong outside of Helm we add that to the
-		// controller context in the release resource. So we include this
-		// information in the CR status.
-		if cc.Status.Reason != "" {
-			status := v1alpha1.ChartStatus{
-				Reason: cc.Status.Reason,
-				Release: v1alpha1.ChartStatusRelease{
-					LastDeployed: metav1.Time{},
-					Status:       cc.Status.Release.Status,
-				},
-			}
-
-			err = r.setStatus(ctx, cr, status)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		}
-
 		// Return early. We will retry on the next execution.
 		return nil
 	} else if err != nil {
@@ -63,13 +63,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		if key.IsCordoned(cr) {
 			status = releaseStatusCordoned
 			reason = key.CordonReason(cr)
-		} else if cc.Status.Reason != "" {
-			// A Helm release exists for this chart CR but data was also added
-			// to the controller context. We do this if something goes wrong
-			// outside of Helm such as pulling the chart tarball. So we ensure
-			// both messages are included in the CR status.
-			status = cc.Status.Release.Status
-			reason = fmt.Sprintf("Helm reason: %s Operator reason: %s", releaseContent.Description, cc.Status.Reason)
 		} else {
 			status = releaseContent.Status
 			if releaseContent.Status != helmclient.StatusDeployed {


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/13677

When chart-operator update the chart CR's status with the new helm revision number, it actually updates resourceVersion on the spec and induces another reconciliation, which triggers infinite helm upgrade behaviors. 

This is a patch which using `addStatusToContext` to not to update releaseRevision on the status update in case of helm failure. 

## Checklist

- [x] Update changelog in CHANGELOG.md.