### PR TITLE
Fix comparison of last deployed and revision fields in chart CR status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix comparison of last deployed and revision optional fields in status resource.
+
 ## [2.5.0] - 2020-11-09
 
 ### Added

--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/helmclient/v3/pkg/helmclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/to"
+	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/helmclient/v3/pkg/helmclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/to"
-	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -97,8 +96,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if !equals(desiredStatus, key.ChartStatus(cr)) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("STATUS DIFF %s", cmp.Diff(desiredStatus, key.ChartStatus(cr))))
-
 		err = r.setStatus(ctx, cr, desiredStatus)
 		if err != nil {
 			return microerror.Mask(err)

--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -89,7 +89,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		Version: releaseContent.Version,
 	}
 	if !releaseContent.LastDeployed.IsZero() {
-		desiredStatus.Release.LastDeployed = &metav1.Time{Time: releaseContent.LastDeployed}
+		// We convert the timestamp to the nearest second to match the value in
+		// the chart CR status.
+		lastDeployed := releaseContent.LastDeployed.Unix()
+		desiredStatus.Release.LastDeployed = &metav1.Time{Time: time.Unix(lastDeployed, 0)}
 	}
 
 	if !equals(desiredStatus, key.ChartStatus(cr)) {

--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -96,6 +96,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if !equals(desiredStatus, key.ChartStatus(cr)) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("STATUS DIFF %s", cmp.Diff(desiredStatus, key.ChartStatus(cr))))
+
 		err = r.setStatus(ctx, cr, desiredStatus)
 		if err != nil {
 			return microerror.Mask(err)

--- a/service/controller/chart/resource/status/resource.go
+++ b/service/controller/chart/resource/status/resource.go
@@ -84,9 +84,19 @@ func equals(a, b v1alpha1.ChartStatus) bool {
 	if a.AppVersion != b.AppVersion {
 		return false
 	}
-	if !a.Release.LastDeployed.Equal(b.Release.LastDeployed) {
+
+	var lastDeployedA, lastDeployedB int64
+
+	if a.Release.LastDeployed != nil {
+		lastDeployedA = a.Release.LastDeployed.Unix()
+	}
+	if b.Release.LastDeployed != nil {
+		lastDeployedB = b.Release.LastDeployed.Unix()
+	}
+	if lastDeployedA != lastDeployedB {
 		return false
 	}
+
 	if a.Reason != b.Reason {
 		return false
 	}

--- a/service/controller/chart/resource/status/resource.go
+++ b/service/controller/chart/resource/status/resource.go
@@ -83,7 +83,7 @@ func equals(a, b v1alpha1.ChartStatus) bool {
 	if a.AppVersion != b.AppVersion {
 		return false
 	}
-	if a.Release.LastDeployed != b.Release.LastDeployed {
+	if !a.Release.LastDeployed.Equal(b.Release.LastDeployed) {
 		return false
 	}
 	if a.Reason != b.Reason {

--- a/service/controller/chart/resource/status/resource.go
+++ b/service/controller/chart/resource/status/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/helmclient/v3/pkg/helmclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/to"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -89,7 +90,7 @@ func equals(a, b v1alpha1.ChartStatus) bool {
 	if a.Reason != b.Reason {
 		return false
 	}
-	if a.Release.Revision != b.Release.Revision {
+	if to.Int(a.Release.Revision) != to.Int(b.Release.Revision) {
 		return false
 	}
 	if a.Release.Status != b.Release.Status {

--- a/service/controller/chart/resource/status/resource.go
+++ b/service/controller/chart/resource/status/resource.go
@@ -90,9 +90,19 @@ func equals(a, b v1alpha1.ChartStatus) bool {
 	if a.Reason != b.Reason {
 		return false
 	}
-	if to.Int(a.Release.Revision) != to.Int(b.Release.Revision) {
+
+	var revisionA, revisionB int
+
+	if a.Release.Revision != nil {
+		revisionA = to.Int(a.Release.Revision)
+	}
+	if b.Release.Revision != nil {
+		revisionB = to.Int(b.Release.Revision)
+	}
+	if revisionA != revisionB {
 		return false
 	}
+
 	if a.Release.Status != b.Release.Status {
 		return false
 	}

--- a/service/controller/chart/resource/status/resource_test.go
+++ b/service/controller/chart/resource/status/resource_test.go
@@ -130,6 +130,30 @@ func Test_StatusResource_equals(t *testing.T) {
 			},
 			equal: false,
 		},
+		{
+			name: "case 6: last deployed different nanos same seconds",
+			statusA: v1alpha1.ChartStatus{
+				AppVersion: "1.0.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					LastDeployed: &metav1.Time{Time: time.Date(2020, 12, 1, 9, 0, 30, 0, time.UTC)},
+					Revision:     to.IntP(1),
+					Status:       "deployed",
+				},
+				Version: "2.1.0",
+			},
+			statusB: v1alpha1.ChartStatus{
+				AppVersion: "1.0.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					LastDeployed: &metav1.Time{Time: time.Date(2020, 12, 1, 9, 0, 30, 30, time.UTC)},
+					Revision:     to.IntP(1),
+					Status:       "deployed",
+				},
+				Version: "2.1.0",
+			},
+			equal: true,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/service/controller/chart/resource/status/resource_test.go
+++ b/service/controller/chart/resource/status/resource_test.go
@@ -1,0 +1,145 @@
+package status
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/to"
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_StatusResource_equals(t *testing.T) {
+	testCases := []struct {
+		name    string
+		statusA v1alpha1.ChartStatus
+		statusB v1alpha1.ChartStatus
+		equal   bool
+	}{
+		{
+			name: "case 0: both equal",
+			statusA: v1alpha1.ChartStatus{
+				AppVersion: "1.0.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					LastDeployed: &metav1.Time{Time: time.Date(2020, 12, 1, 9, 0, 0, 0, time.UTC)},
+					Revision:     to.IntP(1),
+					Status:       "deployed",
+				},
+				Version: "2.1.0",
+			},
+			statusB: v1alpha1.ChartStatus{
+				AppVersion: "1.0.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					LastDeployed: &metav1.Time{Time: time.Date(2020, 12, 1, 9, 0, 0, 0, time.UTC)},
+					Revision:     to.IntP(1),
+					Status:       "deployed",
+				},
+				Version: "2.1.0",
+			},
+			equal: true,
+		},
+		{
+			name:    "case 1: both empty",
+			statusA: v1alpha1.ChartStatus{},
+			statusB: v1alpha1.ChartStatus{},
+			equal:   true,
+		},
+		{
+			name:    "case 2: empty A, non-empty B",
+			statusA: v1alpha1.ChartStatus{},
+			statusB: v1alpha1.ChartStatus{
+				AppVersion: "1.0.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					Revision: to.IntP(1),
+					Status:   "deployed",
+				},
+				Version: "2.1.0",
+			},
+			equal: false,
+		},
+		{
+			name: "case 3: different version",
+			statusA: v1alpha1.ChartStatus{
+				AppVersion: "1.0.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					Revision: to.IntP(1),
+					Status:   "deployed",
+				},
+				Version: "2.1.0",
+			},
+			statusB: v1alpha1.ChartStatus{
+				AppVersion: "1.1.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					Revision: to.IntP(1),
+					Status:   "deployed",
+				},
+				Version: "2.2.0",
+			},
+			equal: false,
+		},
+		{
+			name: "case 4: different revision",
+			statusA: v1alpha1.ChartStatus{
+				AppVersion: "1.0.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					Revision: to.IntP(1),
+					Status:   "deployed",
+				},
+				Version: "2.1.0",
+			},
+			statusB: v1alpha1.ChartStatus{
+				AppVersion: "1.0.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					Revision: to.IntP(2),
+					Status:   "deployed",
+				},
+				Version: "2.1.0",
+			},
+			equal: false,
+		},
+		{
+			name: "case 5: different last deployd",
+			statusA: v1alpha1.ChartStatus{
+				AppVersion: "1.0.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					LastDeployed: &metav1.Time{Time: time.Date(2020, 12, 1, 9, 0, 0, 0, time.UTC)},
+					Revision:     to.IntP(1),
+					Status:       "deployed",
+				},
+				Version: "2.1.0",
+			},
+			statusB: v1alpha1.ChartStatus{
+				AppVersion: "1.0.0",
+				Reason:     "",
+				Release: v1alpha1.ChartStatusRelease{
+					LastDeployed: &metav1.Time{Time: time.Date(2020, 12, 1, 12, 0, 0, 0, time.UTC)},
+					Revision:     to.IntP(1),
+					Status:       "deployed",
+				},
+				Version: "2.1.0",
+			},
+			equal: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			result := equals(tc.statusA, tc.statusB)
+			if result != tc.equal {
+				t.Fatalf("result == %t, want %t\n%s", result, tc.equal, cmp.Diff(tc.statusA, tc.statusB))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14642

We recently made last deployed and revision optional fields in the chart CR status but I screwed up the comparison in the status resource when it got integrated.

This caused chart-operator to OOM on `exodus`. As the status resource was updating the CR status on each loop and having problems calling the status webhook.

## Checklist

- [x] Update changelog in CHANGELOG.md.