### PR TITLE
Add support for vertical pod autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add vertical pod autoscaler support.
+
 ### Fixed
 
 - Fix comparison of last deployed and revision optional fields in status resource.

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -103,6 +103,4 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
-          requests:
-            cpu: 250m
-            memory: 250Mi
+{{ toYaml .Values.deployment | indent 10 }}

--- a/helm/chart-operator/templates/vpa.yaml
+++ b/helm/chart-operator/templates/vpa.yaml
@@ -1,4 +1,6 @@
 {{ if (.Values.Installation) }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace . }}

--- a/helm/chart-operator/templates/vpa.yaml
+++ b/helm/chart-operator/templates/vpa.yaml
@@ -1,0 +1,19 @@
+{{ if (.Values.Installation) }}
+metadata:
+  name: {{ tpl .Values.resource.default.name  . }}
+  namespace: {{ tpl .Values.resource.default.namespace . }}
+  labels:
+    {{- include "chart-operator.labels" . | nindent 4 }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: {{ .Chart.Name }}
+      controlledValues: RequestsAndLimits
+      mode: Auto
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name:  {{ tpl .Values.resource.default.name  . }}
+  updatePolicy:
+    updateMode: Auto
+{{ end }}

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -13,8 +13,11 @@ cluster:
 
 deployment:
   requests:
-    cpu: 250m
-    memory: 250Mi
+    cpu: 400m
+    memory: 390Mi
+  limits:
+    cpu: 750m
+    memory: 500Mi
 
 helm:
   http:

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -1,10 +1,20 @@
 clusterDNSIP: 172.31.0.10
 
-e2e: false
 cnr:
   address: https://quay.io
 
+e2e: false
+
 externalDNSIP: 8.8.8.8
+
+cluster:
+  kubernetes:
+    domain: cluster.local
+
+deployment:
+  requests:
+    cpu: 250m
+    memory: 250Mi
 
 helm:
   http:
@@ -50,7 +60,3 @@ resource:
 
 tiller:
   namespace: "kube-system"
-
-cluster:
-  kubernetes:
-    domain: cluster.local


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14642

Adds VPA support and enables it when chart-operator is installed from the control plane catalog.

```yaml
kg get vpa chart-operator-unique -o yaml

apiVersion: autoscaling.k8s.io/v1
kind: VerticalPodAutoscaler
metadata:
  labels:
    app: chart-operator
    ...
  name: chart-operator-unique
  namespace: giantswarm
spec:
  resourcePolicy:
    containerPolicies:
    - containerName: chart-operator
      controlledValues: RequestsAndLimits
      mode: Auto
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: chart-operator-unique
  updatePolicy:
    updateMode: Auto
status:
  conditions:
  - lastTransitionTime: "2020-12-01T14:44:20Z"
    status: "True"
    type: RecommendationProvided
  recommendation:
    containerRecommendations:
    - containerName: chart-operator
      lowerBound:
        cpu: 34m
        memory: "104857600"
      target:
        cpu: 442m
        memory: "248153480"
      uncappedTarget:
        cpu: 442m
        memory: "248153480"
      upperBound:
        cpu: 629m
        memory: "285237437"
```

## Checklist

- [x] Update changelog in CHANGELOG.md.