### PR TITLE
Reduce requests and set memory limits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,49 +63,6 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-chart-operator-to-aws-app-collection
-          app_name: "chart-operator"
-          app_collection_repo: "aws-app-collection"
-          unique: "true"
-          requires:
-            - push-chart-operator-to-aliyun
-            - push-chart-operator-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-chart-operator-to-azure-app-collection
-          app_name: "chart-operator"
-          app_collection_repo: "azure-app-collection"
-          unique: "true"
-          requires:
-            - push-chart-operator-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-chart-operator-to-kvm-app-collection
-          app_name: "chart-operator"
-          app_collection_repo: "kvm-app-collection"
-          unique: "true"
-          requires:
-            - push-chart-operator-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
       - architect/integration-test:
           context: architect
           name: basic-integration-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Fixed
 
 - Fix comparison of last deployed and revision optional fields in status resource.
+- Set memory limit and reduce requests.
 
 ## [2.5.0] - 2020-11-09
 

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -103,6 +103,4 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
-          requests:
-            cpu: 250m
-            memory: 250Mi
+{{ toYaml .Values.deployment | indent 10 }}

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -10,7 +10,9 @@ cluster:
 
 deployment:
   requests:
-    cpu: 250m
+    cpu: 50m
+    memory: 100Mi
+  limits:
     memory: 250Mi
 
 helm:

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -1,8 +1,5 @@
 clusterDNSIP: 172.31.0.10
 
-cnr:
-  address: https://quay.io
-
 e2e: false
 
 externalDNSIP: 8.8.8.8

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -1,10 +1,20 @@
 clusterDNSIP: 172.31.0.10
 
-e2e: false
 cnr:
   address: https://quay.io
 
+e2e: false
+
 externalDNSIP: 8.8.8.8
+
+cluster:
+  kubernetes:
+    domain: cluster.local
+
+deployment:
+  requests:
+    cpu: 250m
+    memory: 250Mi
 
 helm:
   http:
@@ -50,7 +60,3 @@ resource:
 
 tiller:
   namespace: "kube-system"
-
-cluster:
-  kubernetes:
-    domain: cluster.local


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14642

Reduces the requests as they are too high for tenant clusters. This was done previously by @corest in https://github.com/giantswarm/chart-operator/pull/543.

It also re-introduces the memory limit. If chart-operator is blocked by the API server it can create a lot of secrets which increases the memory usage. Without the memory limit the node can OOM.

The requests are too low for control planes. I'm testing out using VPA in control planes. If that doesn't work we can increase the requests via config.

## Checklist

- [x] Update changelog in CHANGELOG.md.