### PR TITLE
Add VPA flag to values and re-enable push to app collections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,3 +70,46 @@ workflows:
           requires:
           - go-build
           - push-chart-operator-to-default-app-catalog
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-chart-operator-to-aws-app-collection
+          app_name: "chart-operator"
+          app_collection_repo: "aws-app-collection"
+          unique: "true"
+          requires:
+            - push-chart-operator-to-aliyun
+            - push-chart-operator-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-chart-operator-to-azure-app-collection
+          app_name: "chart-operator"
+          app_collection_repo: "azure-app-collection"
+          unique: "true"
+          requires:
+            - push-chart-operator-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-chart-operator-to-kvm-app-collection
+          app_name: "chart-operator"
+          app_collection_repo: "kvm-app-collection"
+          unique: "true"
+          requires:
+            - push-chart-operator-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/helm/chart-operator/templates/vpa.yaml
+++ b/helm/chart-operator/templates/vpa.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.verticalPodAutoscaler.enabled or (.Values.Installation) }}
+{{ if or (.Values.verticalPodAutoscaler.enabled) (.Values.Installation) }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/helm/chart-operator/templates/vpa.yaml
+++ b/helm/chart-operator/templates/vpa.yaml
@@ -1,4 +1,4 @@
-{{ if (.Values.Installation) }}
+{{ if .Values.verticalPodAutoscaler.enabled or (.Values.Installation) }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -61,4 +61,4 @@ tiller:
   namespace: "kube-system"
 
 verticalPodAutoscaler:
-  enabled: "false"
+  enabled: false

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -59,3 +59,6 @@ resource:
 
 tiller:
   namespace: "kube-system"
+
+verticalPodAutoscaler:
+  enabled: "false"

--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -15,4 +15,7 @@ Installation:
         ClientTimeout: 30s
     Registry:
       Domain: quay.io
+
+verticalPodAutoscaler:
+  enabled: false
 `


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14642

Fixes the VPA templating so it can be controlled via the chart values. This is so we can disable VPA in integration tests.

Also re-enables pushing to app collections which was disabled due to a customer change freeze.

## Checklist

- [x] Update changelog in CHANGELOG.md.