### PR TITLE
Delete two meaningless logs

### DIFF
--- a/service/controller/chart/resource/release/create.go
+++ b/service/controller/chart/resource/release/create.go
@@ -29,7 +29,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	}
 
 	if releaseState.Name == "" {
-		r.logger.Debugf(ctx, "no release name is provided for %#q", cr.Name)
+		// no-op
 		return nil
 	}
 

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -32,7 +32,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	}
 
 	if releaseState.Name == "" {
-		r.logger.Debugf(ctx, "no release name is provided for %#q", cr.Name)
+		// no-op
 		return nil
 	}
 


### PR DESCRIPTION
There are too many these logs from control-plane.
I think it's sufficient to return from here without logs. 
```
D 12/09 15:55:44 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/route53-manager-unique release.NewUpdatePatch the `route53-manager-unique` release does not have to be updated | micrologger@v0.4.0/logger.go:53 | controller=chart-operator-chart | event=update | loop=16 | version=169866105
D 12/09 15:55:44 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/route53-manager-unique release.ApplyCreateChange no release name is provided for `route53-manager-unique` | micrologger@v0.4.0/logger.go:53 | controller=chart-operator-chart | event=update | loop=16 | version=169866105
D 12/09 15:55:44 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/route53-manager-unique release.ApplyUpdateChange no release name is provided for `route53-manager-unique` | micrologger@v0.4.0/logger.go:53 | controller=chart-operator-chart | event=update | loop=16 | version=169866105
```