### PR TITLE
Only create VPA if CRD is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Only create VPA if autoscaling API group is present.
+
 ## [2.7.0] - 2021-01-07
 
 ### Added

--- a/helm/chart-operator/templates/vpa.yaml
+++ b/helm/chart-operator/templates/vpa.yaml
@@ -1,4 +1,4 @@
-{{ if or (.Values.verticalPodAutoscaler.enabled) (.Values.Installation) }}
+{{ if and (.Capabilities.APIVersions.Has autoscaling.k8s.io/v1) (.Values.verticalPodAutoscaler.enabled) }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/helm/chart-operator/templates/vpa.yaml
+++ b/helm/chart-operator/templates/vpa.yaml
@@ -1,4 +1,4 @@
-{{ if and (.Capabilities.APIVersions.Has autoscaling.k8s.io/v1) (.Values.verticalPodAutoscaler.enabled) }}
+{{ if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.verticalPodAutoscaler.enabled) }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -61,4 +61,4 @@ tiller:
   namespace: "kube-system"
 
 verticalPodAutoscaler:
-  enabled: false
+  enabled: true


### PR DESCRIPTION
First attempt to disable VPA in integration tests didn't work. This uses `Capabilities.APIVersions` to check if the autoscaling API group is present.

## Checklist

- [x] Update changelog in CHANGELOG.md.