### PR TITLE
Install PriorityClass if not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Pause Chart CR reconciliation when it has chart-operator.giantswarm.io/paused=true annotation.
 
+### Changed
+
+- Deploy `giantswarm-critical` PriorityClass when it's not found.
+
 ## [2.9.0] - 2021-02-03
 
 ### Added

--- a/helm/chart-operator/templates/priorityclass.yaml
+++ b/helm/chart-operator/templates/priorityclass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.e2e }}
+{{- if or .Values.e2e (not (lookup "scheduling.k8s.io/v1" "PriorityClass" "" "giantswarm-critical")) }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:


### PR DESCRIPTION
Towards giantswarm/giantswarm#16005
Reason: When deployed in CAPI WC, `chart-operator` fails to start due to missing `giantswarm-critical` PriorityClass. 

## Checklist

- [x] Update changelog in CHANGELOG.md.
