### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ spec:
     secret:
       name: "prometheus-secrets"
       namespace: "monitoring"
-  tarballURL: "https://giantswarm.github.com/app-catalog/prometheus-1-0-0.tgz"
+  tarballURL: "https://giantswarm.github.io/app-catalog/prometheus-1-0-0.tgz"
 ```
 
 ## Getting Project


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898