### PR TITLE
Handling unknown helm errors

### DIFF
--- a/service/controller/chart/resource/release/create.go
+++ b/service/controller/chart/resource/release/create.go
@@ -140,7 +140,6 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	} else if err != nil {
-		//reason := err.Error()
 		r.logger.Errorf(ctx, err, "helm release %#q failed", releaseState.Name)
 
 		releaseContent, relErr := r.helmClient.GetReleaseContent(ctx, ns, releaseState.Name)

--- a/service/controller/chart/resource/release/resource.go
+++ b/service/controller/chart/resource/release/resource.go
@@ -48,7 +48,7 @@ const (
 	// not apply for failures.
 	releaseFailedMaxAttempts = 5
 
-	// unknownError when a release fails by unknown reasons.
+	// unknownError when a release fails for unknown reasons.
 	unknownError = "unknown-error"
 
 	// validationFailedStatus is set in the CR status when it failed to pass

--- a/service/controller/chart/resource/release/resource.go
+++ b/service/controller/chart/resource/release/resource.go
@@ -48,6 +48,9 @@ const (
 	// not apply for failures.
 	releaseFailedMaxAttempts = 5
 
+	// unknownError when a release fails by unknown reasons.
+	unknownError = "unknown-error"
+
 	// validationFailedStatus is set in the CR status when it failed to pass
 	// OpenAPI validation on release manifest.
 	validationFailedStatus = "validation-failed"


### PR DESCRIPTION
When chart-operator handles unknown helm errors, it didn't update its status so the previous status has been preserved.   

Even though these changes would show users `unknown-error`, this is still far better than being unnoticed. 

## Checklist

- [x] Update changelog in CHANGELOG.md.