### PR TITLE
Use architect-orb 2.10.0 to use k8s 1.21 in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@2.9.0
+  architect: giantswarm/architect@2.10.0
 
 workflows:
   build:


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.