### PR TITLE
Allow installing CNI apps for CAPI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use host network, so chart-operator can install CNI packaged as an app.
+- Add tolerations to start on `NotReady` nodes.
+
 ## [2.15.0] - 2021-05-20
 
 ### Added

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -39,9 +39,18 @@ spec:
             path: config.yaml
       priorityClassName: giantswarm-critical
       serviceAccountName: {{ tpl .Values.resource.default.name  . }}
+      {{- if .Values.chartOperator.cni.install }}
+      hostNetwork: true
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      {{- else }}
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      {{- end }}
       {{ if (.Values.Installation) }}
       dnsPolicy: ClusterFirst
       {{ else }}

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -1,3 +1,8 @@
+# For CAPI clusters this will be set to true. So charts for CNI apps can be installed.
+chartOperator:
+  cni:
+    install: false
+
 cluster:
   kubernetes:
     domain: cluster.local


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/320

This is so we can merge the changes from @kubasobon in https://github.com/giantswarm/chart-operator/pull/721

To enable these settings the cluster values configmap will have `chartOperator.cni.install` set to true. Otherwise we use the current settings.

## Checklist

- [x] Update changelog in CHANGELOG.md.