### PR TITLE
Improve status message when helm release has failed max number of times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Prepare helm values to configuration management.
 - Update architect-orb to v3.0.0.
 
+### Fixed
+
+- Improve status message when helm release has failed max number of attempts.
+
 ## [2.16.0] - 2021-06-03
 
 ### Changed

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -8,6 +8,13 @@ var (
 	version     = "2.16.1-dev"
 )
 
+const (
+	// ReleaseFailedMaxAttempts when a release fails this number of times in a
+	// row we stop updating. This is because the Helm max history setting does
+	// not apply for failures.
+	ReleaseFailedMaxAttempts = 5
+)
+
 // ChartVersion is fixed for chart CRs. This is because they exist in both
 // control plane and tenant clusters and their version is not linked to a
 // release. We may revisit this in future.

--- a/service/controller/chart/controllercontext/context.go
+++ b/service/controller/chart/controllercontext/context.go
@@ -20,7 +20,8 @@ type Status struct {
 }
 
 type Release struct {
-	Status string
+	FailedMaxAttempts bool
+	Status            string
 }
 
 func NewContext(ctx context.Context, c Context) context.Context {

--- a/service/controller/chart/resource/release/resource.go
+++ b/service/controller/chart/resource/release/resource.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/chart-operator/v2/pkg/annotation"
+	"github.com/giantswarm/chart-operator/v2/pkg/project"
 	"github.com/giantswarm/chart-operator/v2/service/controller/chart/controllercontext"
 	"github.com/giantswarm/chart-operator/v2/service/controller/chart/key"
 )
@@ -42,11 +43,6 @@ const (
 	// releaseNotInstalledStatus is set in the CR status when there is no Helm
 	// Release to check.
 	releaseNotInstalledStatus = "not-installed"
-
-	// releaseFailedMaxAttempts when a release fails this number of times in a
-	// row we stop updating. This is because the Helm max history setting does
-	// not apply for failures.
-	releaseFailedMaxAttempts = 5
 
 	// unknownError when a release fails for unknown reasons.
 	unknownError = "unknown-error"
@@ -243,7 +239,7 @@ func (r *Resource) isReleaseFailedMaxAttempts(ctx context.Context, namespace, re
 		return false, microerror.Mask(err)
 	}
 
-	if len(history) < releaseFailedMaxAttempts {
+	if len(history) < project.ReleaseFailedMaxAttempts {
 		return false, nil
 	}
 
@@ -252,7 +248,7 @@ func (r *Resource) isReleaseFailedMaxAttempts(ctx context.Context, namespace, re
 		return history[i].Revision > history[j].Revision
 	})
 
-	for i := 0; i < releaseFailedMaxAttempts; i++ {
+	for i := 0; i < project.ReleaseFailedMaxAttempts; i++ {
 		if history[i].Status != helmclient.StatusFailed {
 			return false, nil
 		}

--- a/service/controller/chart/resource/release/update_test.go
+++ b/service/controller/chart/resource/release/update_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/spf13/afero"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/chart-operator/v2/service/controller/chart/controllercontext"
 )
 
 func Test_Resource_Release_newUpdateChange(t *testing.T) {
@@ -162,9 +164,15 @@ func Test_Resource_Release_newUpdateChange(t *testing.T) {
 		}
 	}
 
+	var ctx context.Context
+	{
+		c := controllercontext.Context{}
+		ctx = controllercontext.NewContext(context.Background(), c)
+	}
+
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			result, err := newResource.newUpdateChange(context.TODO(), &tc.obj, tc.currentState, tc.desiredState)
+			result, err := newResource.newUpdateChange(ctx, &tc.obj, tc.currentState, tc.desiredState)
 			if err != nil {
 				t.Fatal("expected", nil, "got", err)
 			}

--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/chart-operator/v2/pkg/annotation"
+	"github.com/giantswarm/chart-operator/v2/pkg/project"
 	"github.com/giantswarm/chart-operator/v2/service/controller/chart/controllercontext"
 	"github.com/giantswarm/chart-operator/v2/service/controller/chart/key"
 )
@@ -73,7 +75,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		} else {
 			status = releaseContent.Status
 			if releaseContent.Status != helmclient.StatusDeployed {
-				reason = releaseContent.Description
+				if cc.Status.Release.FailedMaxAttempts {
+					reason = fmt.Sprintf("Release has failed %d times and will not be updated.\nReason: %s",
+						project.ReleaseFailedMaxAttempts,
+						releaseContent.Description)
+				} else {
+					reason = releaseContent.Description
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/17314

When chart-operator fails to update a helm release 5 times we stop updating. This is because the max history of 10 revisions is not respected and 100s of release secrets can be created which impacts the cluster.

This improves the CR status so its clearer when this has happened.

## Checklist

- [x] Update changelog in CHANGELOG.md.