### PR TITLE
Parametrize `dig` with used image registry

### DIFF
--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -70,19 +70,11 @@ spec:
           value: "5"
       initContainers:
       - name: wait-for-quay
-        {{ if .Values.isManagementCluster }}
-        image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-        {{ else }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-        {{ end }}
         command:
         - sh
         - -c
-        {{ if .Values.isManagementCluster }}
-        - until dig {{ .Values.registry.domain }}. {{ range (splitList "," .Values.externalDNSIP) }}@{{ . }} {{ end }}; do echo waiting for {{ .Values.registry.domain }}; sleep 2; done;
-        {{ else }}
         - until dig {{ .Values.image.registry }}. {{ range (splitList "," .Values.externalDNSIP) }}@{{ . }} {{ end }}; do echo waiting for {{ .Values.image.registry }}; sleep 2; done;
-        {{ end }}
         securityContext:
           runAsUser: {{ .Values.pod.user.id }}
           runAsGroup: {{ .Values.pod.group.id }}

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -78,7 +78,11 @@ spec:
         command:
         - sh
         - -c
-        - until dig quay.io. {{ range (splitList "," .Values.externalDNSIP) }}@{{ . }} {{ end }}; do echo waiting for quay.io; sleep 2; done;
+        {{ if .Values.isManagementCluster }}
+        - until dig {{ .Values.registry.domain }}. {{ range (splitList "," .Values.externalDNSIP) }}@{{ . }} {{ end }}; do echo waiting for {{ .Values.registry.domain }}; sleep 2; done;
+        {{ else }}
+        - until dig {{ .Values.image.registry }}. {{ range (splitList "," .Values.externalDNSIP) }}@{{ . }} {{ end }}; do echo waiting for {{ .Values.image.registry }}; sleep 2; done;
+        {{ end }}
         securityContext:
           runAsUser: {{ .Values.pod.user.id }}
           runAsGroup: {{ .Values.pod.group.id }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17459

This is especially important in China. Example:
```
chart-operator-unique-f7d49ff56-m5mhs   0/1     Init:0/1   0          27m
```

## Checklist

- [ ] Update changelog in CHANGELOG.md.