### PR TITLE
Better support for barebone clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- When running in `cni.install` mode, ensure the pod is scheduled on masters only and avoid need for kube-proxy.
+
 ## [2.22.0] - 2022-05-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+- Always create `giantswarm-critical` priority class if it does not exist.
 - When running in `cni.install` mode, ensure the pod is scheduled on masters only and avoid need for kube-proxy.
 
 ## [2.22.0] - 2022-05-30

--- a/helm/chart-operator/Chart.yaml
+++ b/helm/chart-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: chart-operator
-version: 1.0.0
-appVersion: 1.0.0
+version: [[ .Version ]]
+appVersion: [[ .AppVersion ]]
 home: https://github.com/giantswarm/chart-operator
 description: A Helm chart for the chart-operator
 annotations:

--- a/helm/chart-operator/Chart.yaml
+++ b/helm/chart-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: chart-operator
-version: [[ .Version ]]
-appVersion: [[ .AppVersion ]]
+version: 1.0.0
+appVersion: 1.0.0
 home: https://github.com/giantswarm/chart-operator
 description: A Helm chart for the chart-operator
 annotations:

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -46,9 +46,6 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
-      env:
-        - name: KUBERNETES_SERVICE_HOST
-          value: 127.0.0.1
       {{- else }}
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -84,8 +81,12 @@ spec:
       {{ end }}
       containers:
       - name: {{ .Chart.Name }}
-        {{- if .Values.proxy.enabled }}
+        {{- if or .Values.proxy.enabled .Values.chartOperator.cni.install }}
         env:
+        {{- if .Values.chartOperator.cni.install }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
+        {{- end }}
         {{- if .Values.proxy.http }}
         - name: HTTP_PROXY
           value: {{ .Values.proxy.http }}
@@ -99,11 +100,11 @@ spec:
           value: {{ join "," .Values.proxy.noProxy }}
         {{- end }}
         {{- end }}
-        {{ if .Values.isManagementCluster }}
+        {{- if .Values.isManagementCluster }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-        {{ else }}
+        {{- else }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-        {{ end }}
+        {{- end }}
         volumeMounts:
         - name: {{ tpl .Values.resource.default.name  . }}-configmap
           mountPath: /var/run/{{ .Chart.Name }}/configmap/

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -41,11 +41,14 @@ spec:
       serviceAccountName: {{ tpl .Values.resource.default.name  . }}
       {{- if .Values.chartOperator.cni.install }}
       hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       tolerations:
       - effect: NoSchedule
         operator: Exists
-      - effect: NoExecute
-        operator: Exists
+      env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
       {{- else }}
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/helm/chart-operator/templates/priorityclass.yaml
+++ b/helm/chart-operator/templates/priorityclass.yaml
@@ -1,4 +1,5 @@
-{{- if or .Values.chartOperator.cni.install .Values.e2e  }}
+{{- $existing := lookup "scheduling.k8s.io/v1" "PriorityClass" .Release.Namespace "giantswarm-critical" -}}
+{{- if not $existing -}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:


### PR DESCRIPTION
`chart-operator` is one of the first things to be installed in a management cluster, alongside app-operator.

Back in the day, we used to install cluster-critical components (such as the CNI and kube-proxy) as barebone kubernetes manifests, because the chicken-egg problem prevented us to install apps providing such core components using the app platform.

One day we added the `chartOperator.cni.install` flag that allows to run chart operator even on a cluster lacking core components (specifically the CNI) and thus being able to install the CNI as part of a giant swarm Chart.

In this scenario, `kube-proxy` still needed to be installed as part of the master node bootstrap process which is unfortunate.

This PR makes changes to allow running chart operator even on clusters lacking kube-proxy so we can install kube-proxy as a managed app as well.
This is particularly useful now that we're planning to use `cilium` as a kube-proxy implementation.

## Checklist

- [x] Update changelog in CHANGELOG.md.
