### PR TITLE
Always create `giantswarm-critical` priority class if it does not exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Always create `giantswarm-critical` priority class if it does not exist.
+
 ## [2.22.0] - 2022-05-30
 
 ### Added

--- a/helm/chart-operator/templates/priorityclass.yaml
+++ b/helm/chart-operator/templates/priorityclass.yaml
@@ -1,4 +1,4 @@
-{{- $existing := lookup "scheduling.k8s.io/v1" "PriorityClass" .Release.Namespace "giantswarm-critical" -}}
+{{- $existing := lookup "scheduling.k8s.io/v1" "PriorityClass" "" "giantswarm-critical" -}}
 {{- if not $existing -}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass

--- a/helm/chart-operator/templates/priorityclass.yaml
+++ b/helm/chart-operator/templates/priorityclass.yaml
@@ -1,4 +1,5 @@
-{{- if or .Values.chartOperator.cni.install .Values.e2e  }}
+{{- $existing := lookup "scheduling.k8s.io/v1" "PriorityClass" .Release.Namespace "giantswarm-critical" -}}
+{{- if not $existing -}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:


### PR DESCRIPTION
Chart operator needs a priority class named `giantswarm-critical` to exist.
In MCs and in legacy WCs, we used to create such priority class while deploying master nodes (using k8s-addons script inside master nodes).

In CAPI this does not happen any more, so we needed an alternative way of creating the priority class. For that reason we added a feature flag to `chart-operator`'s helm chart named `cni.install` that, among other things, created the priority class while installing the chart.

This has a bunch of problems:

- makes installing chart operator fail when run with `cni.install = true` on a legacy MC or WC (because the priority class exists already there)
- makes installing chart operator  fail in CAPI clusters when run with `cni.install = false` because the priority class is not present and not created.

To try and solve both issues, this PR simply makes the helm chart create the priority class in any case (regardless of the `cni.install` flag's value) when it does not exist.
This will make the chart work in both the aforementioned scenarios.

WDYT?

## Checklist

- [x] Update changelog in CHANGELOG.md.
