### PR TITLE
Initial bootstrap mode

### DIFF
--- a/helm/chart-operator/Chart.yaml
+++ b/helm/chart-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: chart-operator
-version: 1.0.0
-appVersion: 1.0.0
+version: [[ .Version ]]
+appVersion: [[ .AppVersion ]]
 home: https://github.com/giantswarm/chart-operator
 description: A Helm chart for the chart-operator
 annotations:

--- a/helm/chart-operator/Chart.yaml
+++ b/helm/chart-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: chart-operator
-version: [[ .Version ]]
-appVersion: [[ .AppVersion ]]
+version: 1.0.0
+appVersion: 1.0.0
 home: https://github.com/giantswarm/chart-operator
 description: A Helm chart for the chart-operator
 annotations:

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -39,12 +39,12 @@ spec:
             path: config.yaml
       priorityClassName: giantswarm-critical
       serviceAccountName: {{ tpl .Values.resource.default.name  . }}
-      {{- if .Values.chartOperator.cni.install }}
+      {{- if or .Values.chartOperator.cni.install .Values.initialBoostrapMode }}
       hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       tolerations:
       - effect: NoSchedule
-        operator: Exists
-      - effect: NoExecute
         operator: Exists
       {{- else }}
       tolerations:
@@ -81,8 +81,12 @@ spec:
       {{ end }}
       containers:
       - name: {{ .Chart.Name }}
-        {{- if .Values.proxy.enabled }}
+        {{- if or .Values.proxy.enabled .Values.initialBootstrapMode }}
         env:
+        {{- if .Values.initialBootstrapMode }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
+        {{- end }}
         {{- if .Values.proxy.http }}
         - name: HTTP_PROXY
           value: {{ .Values.proxy.http }}
@@ -96,11 +100,11 @@ spec:
           value: {{ join "," .Values.proxy.noProxy }}
         {{- end }}
         {{- end }}
-        {{ if .Values.isManagementCluster }}
+        {{- if .Values.isManagementCluster }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-        {{ else }}
+        {{- else }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-        {{ end }}
+        {{- end }}
         volumeMounts:
         - name: {{ tpl .Values.resource.default.name  . }}-configmap
           mountPath: /var/run/{{ .Chart.Name }}/configmap/

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -39,11 +39,11 @@ spec:
             path: config.yaml
       priorityClassName: giantswarm-critical
       serviceAccountName: {{ tpl .Values.resource.default.name  . }}
-      {{- if .Values.initialBoostrapMode }}
+      {{- if .Values.initialBootstrapMode }}
       nodeSelector:
         node-role.kubernetes.io/master: ""
       {{- end }}
-      {{- if or .Values.chartOperator.cni.install .Values.initialBoostrapMode }}
+      {{- if or .Values.chartOperator.cni.install .Values.initialBootstrapMode }}
       hostNetwork: true
       tolerations:
       - effect: NoSchedule
@@ -53,9 +53,9 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       {{- end }}
-      {{ if .Values.isManagementCluster }}
+      {{- if .Values.isManagementCluster }}
       dnsPolicy: ClusterFirst
-      {{ else }}
+      {{- else }}
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -80,7 +80,7 @@ spec:
         securityContext:
           runAsUser: {{ .Values.pod.user.id }}
           runAsGroup: {{ .Values.pod.group.id }}
-      {{ end }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         {{- if or .Values.proxy.enabled .Values.initialBootstrapMode }}

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -39,10 +39,12 @@ spec:
             path: config.yaml
       priorityClassName: giantswarm-critical
       serviceAccountName: {{ tpl .Values.resource.default.name  . }}
-      {{- if or .Values.chartOperator.cni.install .Values.initialBoostrapMode }}
-      hostNetwork: true
+      {{- if .Values.initialBoostrapMode }}
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      {{- end }}
+      {{- if or .Values.chartOperator.cni.install .Values.initialBoostrapMode }}
+      hostNetwork: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/helm/chart-operator/templates/psp.yaml
+++ b/helm/chart-operator/templates/psp.yaml
@@ -25,6 +25,6 @@ spec:
     - 'configMap'
     - 'secret'
   allowPrivilegeEscalation: false
-  hostNetwork: {{ .Values.chartOperator.cni.install }}
+  hostNetwork: {{ or .Values.chartOperator.cni.install .Values.initialBootstrapMode }}
   hostIPC: false
   hostPID: false

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -79,3 +79,14 @@ verticalPodAutoscaler:
   enabled: true
 
 isManagementCluster: false
+
+# When this flag is true, chart operator runs in special mode in order to be able to run in partially deployed clusters.
+# Main differences are:
+# - runs on master nodes
+# - runs on hostNetwork
+# - tolerates all taints
+# - uses API hostname to reach the API to support kube-proxy being missing
+# This mode is meant to be used during bootstrap of clusters to be able to deploy basic system services
+# (such as the CNI or the out-of-tree cloud controller managers) as a managed app.
+# After the cluster is fully deployed, this flag should be switched to false.
+initialBootstrapMode: false


### PR DESCRIPTION
chart-operator is one of the first things to be installed in a management cluster, alongside app-operator.

Back in the day, we used to install cluster-critical components (such as the CNI and kube-proxy) as barebone kubernetes manifests, because the chicken-egg problem prevented us to install apps providing such core components using the app platform.

One day we added the chartOperator.cni.install flag that allows to run chart operator even on a cluster lacking core components (specifically the CNI) and thus being able to install the CNI as part of a giant swarm Chart.

In this scenario, kube-proxy still needed to be installed as part of the master node bootstrap process which is unfortunate.

This PR adds a new flag `initialBootstrapMode` that relaxes most of chart-operator needs in terms of cluster resources in order to make it run on clusters lacking core components.
This is a backward compatible flag disabled by default, meant to be set to false once the cluster bootstrap is finished.

This is the same behaviour as app-operator

## Checklist

- [x] Update changelog in CHANGELOG.md.
