### PR TITLE
Prevent deletion of PriorityClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add `chart-pull-failed` error to differentiate between issues when pulling chart tarball and other problems.
 
+### Fixed
+
+- Fix missing `PriorityClass` issue.
+
 ## [2.23.0] - 2022-06-06
 
 ### Changed

--- a/helm/chart-operator/templates/priorityclass.yaml
+++ b/helm/chart-operator/templates/priorityclass.yaml
@@ -1,5 +1,15 @@
+{{- $render := false -}}
 {{- $existing := lookup "scheduling.k8s.io/v1" "PriorityClass" "" "giantswarm-critical" -}}
-{{- if or (not $existing) (eq (index $existing.metadata.labels "app.kubernetes.io/instance") "chart-operator") -}}
+{{- if not $existing -}}
+{{- $render = true -}}
+{{- else -}}
+{{- if $existing.metadata.labels -}}
+{{- if eq (index $existing.metadata.labels "app.kubernetes.io/instance") "chart-operator" -}}
+{{- $render = true -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $render -}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/helm/chart-operator/templates/priorityclass.yaml
+++ b/helm/chart-operator/templates/priorityclass.yaml
@@ -1,5 +1,5 @@
 {{- $existing := lookup "scheduling.k8s.io/v1" "PriorityClass" "" "giantswarm-critical" -}}
-{{- if not $existing -}}
+{{- if or (not $existing) (eq (index $existing.metadata.labels "app.kubernetes.io/instance") "chart-operator") -}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:


### PR DESCRIPTION
**Problem**

When the PriorityClass is created by someone else earlier, helm doesn’t render PriorityClass and doesn’t touch the existing one.
When the PriorityClass is created by the same chart for the previous version, helm doesn’t render PriorityClass for the new version and it thinks it should be deleted for the new version and it deletes.

**Solution**
We should keep rendering PriorityClass if it is created by chart-operator earlier to prevent deletion during upgrades.

**Tested Scenarios**
- No PriorityClass -> Render 
- PriorityClass without any label -> Do not render
- PriorityClass created by another helm chart (`app.kubernetes.io/instance: erkan-operator`) -> Do not render
- PriorityClass created by chart-operator earlier (`app.kubernetes.io/instance: chart-operator`) -> Render

Also, note that helm templating doesn't support short-circuit. See https://stackoverflow.com/a/51167460 It is why I used ugly, nested templating. 

## Checklist

- [x] Update changelog in CHANGELOG.md.
