### PR TITLE
Allow to set api server pod port when enabling initialBootstrapMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use downward API to set deployment env var `KUBERNETES_SERVICE_HOST` to `status.hostIP`.
+
+### Added
+
+- Allow to set api server pod port when enabling `initialBootstrapMode`.
+
 ## [2.24.1] - 2022-06-22
 
 ### Changed

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -39,11 +39,11 @@ spec:
             path: config.yaml
       priorityClassName: giantswarm-critical
       serviceAccountName: {{ tpl .Values.resource.default.name  . }}
-      {{- if .Values.initialBootstrapMode }}
+      {{- if .Values.initialBootstrapMode.enabled }}
       nodeSelector:
         node-role.kubernetes.io/master: ""
       {{- end }}
-      {{- if or .Values.chartOperator.cni.install .Values.initialBootstrapMode }}
+      {{- if or .Values.chartOperator.cni.install .Values.initialBootstrapMode.enabled }}
       hostNetwork: true
       tolerations:
       - effect: NoSchedule
@@ -83,11 +83,15 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        {{- if or .Values.proxy.enabled .Values.initialBootstrapMode }}
+        {{- if or .Values.proxy.enabled .Values.initialBootstrapMode.enabled }}
         env:
-        {{- if .Values.initialBootstrapMode }}
+        {{- if .Values.initialBootstrapMode.enabled }}
         - name: KUBERNETES_SERVICE_HOST
-          value: 127.0.0.1
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.initialBootstrapMode.apiServerPodPort | quote }}
         {{- end }}
         {{- if .Values.proxy.http }}
         - name: HTTP_PROXY

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -89,4 +89,6 @@ isManagementCluster: false
 # This mode is meant to be used during bootstrap of clusters to be able to deploy basic system services
 # (such as the CNI or the out-of-tree cloud controller managers) as a managed app.
 # After the cluster is fully deployed, this flag should be switched to false.
-initialBootstrapMode: false
+initialBootstrapMode:
+  apiServerPodPort: 443
+  enabled: false


### PR DESCRIPTION
For the initialBootstrapMode to work we need to use the downward api and use `status.hostIP` as k8s IP, otherwise the certificate won't be valid.

Also we want to use the port where the apiserver is actually listening (`6443`), rather than the one defined on the default kubernetes `Service` (`443`).

## Checklist

- [X] Update changelog in CHANGELOG.md.
