### PR TITLE
Use private helm client for control plane test catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Tighten pod and container security contexts for PSS restricted policies.
 - Use downward API to set deployment env var `KUBERNETES_SERVICE_HOST` to `status.hostIP`.
 - Change `initialBootstrapMode` configuration value to `bootstrapMode`.
+- Use private Helm client for installing app-operators from control-plane-test-catalog
 
 ### Added
 

--- a/service/internal/clientpair/clientpair.go
+++ b/service/internal/clientpair/clientpair.go
@@ -27,6 +27,10 @@ const (
 	// The appOperatorChart defines legal prefix for what elevated Helm Client
 	// can install outside the `giantswarm` namespace.
 	appOperatorChart = "https://giantswarm.github.io/control-plane-catalog/app-operator"
+	// The appOperatorTestChart defines another legal prefix to use the elevated Helm client
+	// used when we are testing changes for workload cluster app-operators that are
+	// generally not located in the giantswarm namespace.
+	appOperatorTestChart = "https://giantswarm.github.io/control-plane-test-catalog/app-operator"
 )
 
 type ClientPairConfig struct {
@@ -96,7 +100,7 @@ func (cp *ClientPair) Get(ctx context.Context, cr v1alpha1.Chart) helmclient.Int
 	}
 
 	// for app operators outside the `giantswarm` namespace, use the prvHelmClient.
-	if key.AppNamespace(cr) != privateNamespace && strings.HasPrefix(key.TarballURL(cr), appOperatorChart) {
+	if key.AppNamespace(cr) != privateNamespace && (strings.HasPrefix(key.TarballURL(cr), appOperatorChart) || strings.HasPrefix(key.TarballURL(cr), appOperatorTestChart)) {
 		cp.logger.Debugf(ctx, "selecting private Helm client for `%s` App in `%s` namespace", key.AppName(cr), key.AppNamespace(cr))
 
 		return cp.prvHelmClient

--- a/service/internal/clientpair/clientpair_test.go
+++ b/service/internal/clientpair/clientpair_test.go
@@ -162,7 +162,7 @@ func Test_Get(t *testing.T) {
 			expectedClient: prvHC,
 		},
 		{
-			name: "split client, WC app operator",
+			name: "split client, WC app operator (control-plane-catalog)",
 			chart: v1alpha1.Chart{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -172,6 +172,22 @@ func Test_Get(t *testing.T) {
 				},
 				Spec: v1alpha1.ChartSpec{
 					TarballURL: appOperatorChart + "-5.9.0.tgz",
+				},
+			},
+			clientPair:     splitClient,
+			expectedClient: prvHC,
+		},
+		{
+			name: "split client, WC app operator (control-plane-test-catalog)",
+			chart: v1alpha1.Chart{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.AppNamespace: "demo0",
+						annotation.AppName:      "app-operator-demo0",
+					},
+				},
+				Spec: v1alpha1.ChartSpec{
+					TarballURL: appOperatorTestChart + "-5.9.0.tgz",
 				},
 			},
 			clientPair:     splitClient,


### PR DESCRIPTION
This is needed to test app-operator changes on WC app-operators. FTR the admission controller will only allow using test catalog for MC staff users.

## Checklist

- [x] Update changelog in CHANGELOG.md.
