### PR TITLE
Use `127.0.0.1` as KUBERNETES_SERVICE_HOST when `bootstrapMode` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use `127.0.0.1` as KUBERNETES_SERVICE_HOST when `bootstrapMode` is enabled.
+
 ## [2.25.0] - 2022-07-04
 
 ### Changed

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -96,9 +96,7 @@ spec:
         env:
         {{- if .Values.bootstrapMode.enabled }}
         - name: KUBERNETES_SERVICE_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
+          value: 127.0.0.1
         - name: KUBERNETES_SERVICE_PORT
           value: {{ .Values.bootstrapMode.apiServerPodPort | quote }}
         {{- end }}


### PR DESCRIPTION
When bootstrapMode is enabled, the chart operator pod:

- runs on master nodes only
- runs on hostNetwork

this means we can safely use 127.0.0.1 as the API server address because it's a safe assumption.

This will make bootstrapMode work on workload clusters as well (the current approach of using the node's IP does not work right now because of how the TLS certificates are generated for WCs).

## Checklist

- [x] Update changelog in CHANGELOG.md.
