### PR TITLE
ensure the PriorityClass is created before any other resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Ensure the `giantswarm` PriorityClass is created first on initial installation.
+
 ## [2.26.0] - 2022-07-20
 
 ### Changed

--- a/helm/chart-operator/templates/priorityclass.yaml
+++ b/helm/chart-operator/templates/priorityclass.yaml
@@ -16,6 +16,10 @@ metadata:
   name: giantswarm-critical
   labels:
     {{- include "chart-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/resource-policy: keep
+    helm.sh/hook-delete-policy: hook-failed
 value: 1000000000
 globalDefault: false
 description: "This priority class is used by giantswarm kubernetes components."


### PR DESCRIPTION
This PR:

- uses a helm `pre-install` hook to ensure the PriorityClass is created before all other resources

This is required because there is sometimes a race condition on initial chart installation where the deployment cannot start because the PriorityClass does not exist.

## Checklist

- [x] Update changelog in CHANGELOG.md.
