### PR TITLE
Fix autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Reconfigure VPA autoscaler to react correctly to pod resource ceilings
+
 ## [2.28.0] - 2022-08-09
 
 ### Changed

--- a/helm/chart-operator/templates/_helpers.tpl
+++ b/helm/chart-operator/templates/_helpers.tpl
@@ -33,3 +33,17 @@ Selector labels
 app.kubernetes.io/name: {{ include "chart-operator.name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end -}}
+
+{{- define "resource.vpa.enabled" -}}
+{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.verticalPodAutoscaler.enabled) }}true{{ else }}false{{ end }}
+{{- end -}}
+
+
+{{- define "deployment.resources" -}}
+requests:
+{{ toYaml .Values.deployment.requests | indent 2 -}}
+{{ if eq (include "resource.vpa.enabled" .) "false" }}
+limits:
+{{ toYaml .Values.deployment.limits | indent 2 -}}
+{{- end -}}
+{{- end -}}

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -147,4 +147,4 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
-{{ toYaml .Values.deployment | indent 10 }}
+{{ include "deployment.resources" . | indent 10 }}

--- a/helm/chart-operator/templates/vpa.yaml
+++ b/helm/chart-operator/templates/vpa.yaml
@@ -1,4 +1,4 @@
-{{ if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.verticalPodAutoscaler.enabled) }}
+{{ if eq (include "resource.vpa.enabled" .) "true" }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -10,7 +10,15 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: {{ .Chart.Name }}
-      controlledValues: RequestsAndLimits
+      controlledResources:
+        - cpu
+        - memory
+      maxAllowed:
+        cpu: 1000m
+        memory: 1000Mi
+      minAllowed:
+        cpu: 250m
+        memory: 250Mi
       mode: Auto
   targetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
## VPA Autoscaler fix

Towards https://github.com/giantswarm/giantswarm/issues/23052

This PR introduces changes to the VPA autoscaler configuration that enable pods to be recreated with correct resources in the event the pod is previously OOM killed by the platform. 

If the autoscaler is disabled in the values file or the cluster doesn't support autoscaling, limits are set from the values file, otherwise the autoscaler is enabled with a maximum ceiling of `1000mi` memory and `1000m` cpu.

## Checklist

- [x] Update changelog in CHANGELOG.md.
