### PR TITLE
Selecting private Helm client on demand

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -34,3 +34,5 @@ CVE-2022-21221 until=2023-06-30
 
 # pkg:golang/k8s.io/apiserver@v0.25.2
 sonatype-2022-6522 until=2023-06-30
+
+CVE-2023-25165 until=2023-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Selecting private Helm client on demand for some operations.
+
 ## [2.33.2] - 2022-12-16
 
 ## [2.33.1] - 2022-12-16

--- a/service/controller/chart/resource/release/create.go
+++ b/service/controller/chart/resource/release/create.go
@@ -25,7 +25,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		return microerror.Mask(err)
 	}
 
-	hc := r.helmClients.Get(ctx, cr)
+	hc := r.helmClients.Get(ctx, cr, false)
 
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {

--- a/service/controller/chart/resource/release/current.go
+++ b/service/controller/chart/resource/release/current.go
@@ -45,7 +45,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	releaseName := key.ReleaseName(cr)
-	releaseContent, err := r.helmClients.Get(ctx, cr).GetReleaseContent(ctx, key.Namespace(cr), releaseName)
+	releaseContent, err := r.helmClients.Get(ctx, cr, true).GetReleaseContent(ctx, key.Namespace(cr), releaseName)
 	if helmclient.IsReleaseNotFound(err) {
 		// Return early as release is not installed.
 		return nil, nil

--- a/service/controller/chart/resource/release/delete.go
+++ b/service/controller/chart/resource/release/delete.go
@@ -18,7 +18,10 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		return microerror.Mask(err)
 	}
 
-	hc := r.helmClients.Get(ctx, cr)
+	// We use elevated Helm client when performing deletion-wise operations to
+	// avoid permissions issues when deleting App Bundles from cluster namespace,
+	// see: https://github.com/giantswarm/giantswarm/issues/25731
+	hc := r.helmClients.Get(ctx, cr, true)
 
 	releaseState, err := toReleaseState(deleteChange)
 	if err != nil {

--- a/service/controller/chart/resource/release/update.go
+++ b/service/controller/chart/resource/release/update.go
@@ -24,7 +24,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		return microerror.Mask(err)
 	}
 
-	hc := r.helmClients.Get(ctx, cr)
+	hc := r.helmClients.Get(ctx, cr, false)
 
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
@@ -323,7 +323,7 @@ func (r *Resource) rollback(ctx context.Context, obj interface{}, currentStatus 
 		return microerror.Mask(err)
 	}
 
-	hc := r.helmClients.Get(ctx, cr)
+	hc := r.helmClients.Get(ctx, cr, false)
 
 	count, ok := cr.GetAnnotations()[annotation.RollbackCount]
 

--- a/service/controller/chart/resource/releasemaxhistory/create.go
+++ b/service/controller/chart/resource/releasemaxhistory/create.go
@@ -111,7 +111,7 @@ func (r *Resource) deleteFailedRelease(ctx context.Context, namespace, releaseNa
 }
 
 func (r *Resource) getReleaseHistory(ctx context.Context, cr v1alpha1.Chart) ([]helmclient.ReleaseHistory, error) {
-	history, err := r.helmClients.Get(ctx, cr, false).GetReleaseHistory(ctx, key.Namespace(cr), key.ReleaseName(cr))
+	history, err := r.helmClients.Get(ctx, cr, true).GetReleaseHistory(ctx, key.Namespace(cr), key.ReleaseName(cr))
 	if helmclient.IsReleaseNotFound(err) {
 		// Fall through
 		return nil, nil

--- a/service/controller/chart/resource/releasemaxhistory/create.go
+++ b/service/controller/chart/resource/releasemaxhistory/create.go
@@ -111,7 +111,7 @@ func (r *Resource) deleteFailedRelease(ctx context.Context, namespace, releaseNa
 }
 
 func (r *Resource) getReleaseHistory(ctx context.Context, cr v1alpha1.Chart) ([]helmclient.ReleaseHistory, error) {
-	history, err := r.helmClients.Get(ctx, cr).GetReleaseHistory(ctx, key.Namespace(cr), key.ReleaseName(cr))
+	history, err := r.helmClients.Get(ctx, cr, false).GetReleaseHistory(ctx, key.Namespace(cr), key.ReleaseName(cr))
 	if helmclient.IsReleaseNotFound(err) {
 		// Fall through
 		return nil, nil

--- a/service/controller/chart/resource/status/create.go
+++ b/service/controller/chart/resource/status/create.go
@@ -35,7 +35,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	releaseName := key.ReleaseName(cr)
 	r.logger.Debugf(ctx, "getting status for release %#q", releaseName)
 
-	releaseContent, err := r.helmClients.Get(ctx, cr).GetReleaseContent(ctx, key.Namespace(cr), releaseName)
+	releaseContent, err := r.helmClients.Get(ctx, cr, false).GetReleaseContent(ctx, key.Namespace(cr), releaseName)
 	if releaseContent != nil {
 		r.logger.Debugf(ctx, "Helm release information %#q", releaseContent.Status)
 	}

--- a/service/internal/clientpair/clientpair_test.go
+++ b/service/internal/clientpair/clientpair_test.go
@@ -213,7 +213,7 @@ func Test_Get(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
-			client := tc.clientPair.Get(context.TODO(), tc.chart)
+			client := tc.clientPair.Get(context.TODO(), tc.chart, false)
 
 			if client != tc.expectedClient {
 				t.Fatalf("got wrong client")


### PR DESCRIPTION
## Description

Towards: https://github.com/giantswarm/giantswarm/issues/25731

### Problem

A while ago we replaced a single Helm client with two, a private (elevated) and public (limited) ones, in response to the security incident we had at the time. The elevated client is mostly used for `giantswarm`-namespaced apps, and used the Chart Operator own Service Account, while the limited client is used for everything else, and impersonated the `automation` ServiceAccount from the `default` namespace. This turns out to pose a problem for App Bundles installed for workload clusters, for when the workload cluster gets deleted, the RBAC setup created by RBACOp in the cluster namespace gets deleted alongside it. Then impersonating the `automation` ServiceAccount results in an error when deleting the app.

To understand this problem better see the example below. When I try to use the `automation` SA to get nonexisting release from nonexisting namespace, I get an error, because this SA does not have cluster-wide permissions to get Secrets the Helm releases are kept in, and since the namespace does not exist, there are obviously no namespace-wise RBAC settings in there that would give me the access:

```bash
> helm --kube-as-user system:serviceaccount:default:automation get all fakerelease -n fakenamespace
Error: query: failed to query with labels: secrets is forbidden: User "system:serviceaccount:default:automation" cannot list resource "secrets" in API group "" in the namespace "fakenamespace"
```

When I do the same using the Chart Operator ServiceAccount all works fine, i.e. I get `not found` error which should get processed by the Chart Operator.

```bash
> helm --kube-as-user system:serviceaccount:giantswarm:chart-operator get all fakerelease -n fakenamespace
Error: release: not found
```

Same goes for deletion. 

### Solution

Now, my assumptions is what we dealt with during the security incident still stands, i.e. it is still desired to limit what the user can install within the management cluster. With that in mind I modified the part of Chart Operator responsible for selecting the client, so now the elevated client can be returned on demand. This on-demand selection is now used in two places - for deletion-related operations and for scanning-related operations. Thanks to this, when the whole namespace is being deleted and the RBAC setup in there with it, the Chart Operator can still perform some operations, and for example find out the release is gone, or attempt to delete it. The installation and upgrade operations still use the client assigned by the selection procedure described [here](https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/appcatalog_internals/#limiting-permissions-of-chart-operator).

### Other Possible Solutions

Other solutions I could think of, listed by preference in descending order, are:

* modify the current client selection a bit, and add App Bundles to [this list](https://github.com/giantswarm/chart-operator/blob/3ccd4e4eb8a92df6b93a2cd77b4621135e5d68a0/service/internal/clientpair/clientpair.go#L103). In result of this, the elevated client would be chosen if App Operator, or one of the App Bundles, is being installed. This however feels problematic to maintain, for we would need to remember to extend the list whenever new bundle is being created, and this may easily get overlooked. But still, this should get fairly easy to implement, and would not stretch permissions too much.
* the elevated Helm client is selected, no matter the operation, for any app under condition it comes from the Giantswarm catalog. We already do something like that for App Operators, see [this part](https://github.com/giantswarm/chart-operator/blob/3ccd4e4eb8a92df6b93a2cd77b4621135e5d68a0/service/internal/clientpair/clientpair.go#L103). We could weaken the condition and for example check for the `https://giantswarm.github.io` prefix in the URL. But the downside of this solution is it would allow the customer to install any app in the management cluster, and for example grant itself elevated permissions, and this would contradict the whole security incident work we did. This basically means reverting to what we had previously, as two Helm clients are no longer necessary. Well, theoretically we could still use limited one for "external" apps, but this wouldn't matter if the customer can access cluster-admin permissions with internal apps.

## Checklist

- [x] Update changelog in CHANGELOG.md.
