### PR TITLE
set-proper-tolarate-taint-for-capi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Changed pod taint toleration to only tolerate `NotReady` for CAPI.
+
 ## [2.35.0] - 2023-05-04
 
 ### Changed

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -65,6 +65,8 @@ spec:
         effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        effect: NoSchedule
       {{- else }}
       tolerations:
       - key: node-role.kubernetes.io/control-plane

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -67,6 +67,8 @@ spec:
         effect: NoSchedule
       - key: node.cloudprovider.kubernetes.io/uninitialized
         effect: NoSchedule
+      - key: node.cluster.x-k8s.io/uninitialized
+        effect: NoSchedule
       {{- else }}
       tolerations:
       - key: node-role.kubernetes.io/control-plane

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -58,9 +58,13 @@ spec:
       {{- if or .Values.chartOperator.cni.install .Values.bootstrapMode.enabled }}
       hostNetwork: true
       tolerations:
-      - effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
+        effect: NoSchedule
         operator: Exists
-        key: node.kubernetes.io/not-ready
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       {{- else }}
       tolerations:
       - key: node-role.kubernetes.io/control-plane

--- a/helm/chart-operator/templates/deployment.yaml
+++ b/helm/chart-operator/templates/deployment.yaml
@@ -60,6 +60,7 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
+        key: node.kubernetes.io/not-ready
       {{- else }}
       tolerations:
       - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
The taint toleration settings for chart-operator in CNI mode (for CAPI) were too open this caused issues that the pod could be scheduled on a node that is cordoned which was causing issues for migration from vintage to CAPI

this PR changes the taint toleration to only tolerate nodes that are in the `NotReady` state
