### PR TITLE
Force-disable PSP-related resources when `global.podSecurityStandards…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Force-disable PSP-related resources when `global.podSecurityStandards.enforced` value is true. 
+- Force-disable PSP-related resources when `global.podSecurityStandards.enforced` value is true.
 
 ## [3.0.0] - 2023-10-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Force-disable PSP-related resources when `global.podSecurityStandards.enforced` value is true. 
+
 ## [3.0.0] - 2023-10-04
 
 ### Removed

--- a/helm/chart-operator/templates/psp.yaml
+++ b/helm/chart-operator/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/chart-operator/templates/rbac.yaml
+++ b/helm/chart-operator/templates/rbac.yaml
@@ -12,6 +12,7 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
+{{- if not .Values.global.podSecurityStandards.enforced }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -43,3 +44,4 @@ roleRef:
   kind: ClusterRole
   name: {{ tpl .Values.resource.psp.name . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/chart-operator/values.schema.json
+++ b/helm/chart-operator/values.schema.json
@@ -86,6 +86,19 @@
         "externalDNSIP": {
             "type": "string"
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "helm": {
             "type": "object",
             "properties": {

--- a/helm/chart-operator/values.yaml
+++ b/helm/chart-operator/values.yaml
@@ -123,3 +123,7 @@ securityContext:
 kyvernoPolicyExceptions:
   enabled: true
   namespace: giantswarm
+
+global:
+  podSecurityStandards:
+    enforced: false


### PR DESCRIPTION
….enforced` value is true.

Towards release 19.3.0

we need PSP feature to be disabled 100% if the global flag is set.

## Checklist

- [x] Update changelog in CHANGELOG.md.
