### PR TITLE
fix: bump architect orb to 9.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@6.15.0
+  architect: giantswarm/architect@9.6.0
 
 workflows:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+- Bump the `architect` CircleCI orb from 6.15.0 to 9.6.0. The 6.x `push-to-app-catalog` job still
+  authenticates to `giantswarmpublic.azurecr.io`, which no longer resolves (NXDOMAIN), so the chart
+  push fails on every build. That step was deprecated in orb 6.8.0 when chart pushes moved to
+  `gsoci`, and is absent from 9.x. 9.6.0 is the version already running in `coredns-app`,
+  `external-dns-app` and `kyverno-policies-dx`.
 - Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
 ## [4.2.0] - 2025-11-26
 


### PR DESCRIPTION
Bumps the `architect` orb to **9.6.0** so the chart-push job stops authenticating to the decommissioned `giantswarmpublic.azurecr.io`.

## Why it fails today

```
Step: [deprecated] architect/push-helm-package: Authenticate to the OCI registry
Error: authenticating to "giantswarmpublic.azurecr.io":
  dial tcp: lookup giantswarmpublic.azurecr.io: no such host
```

`giantswarmpublic.azurecr.io` is **NXDOMAIN** — the registry is gone. The step was marked deprecated in orb **6.8.0**, when chart pushes moved to `gsoci`, but 6.x kept running it. Verified at source level:

| Orb version | `push-to-app-catalog` references `giantswarmpublic` |
|---|---|
| v6.15.0 | **yes** |
| v9.6.0 | no |
| v10.0.0 | no |

## Verified, not assumed

I applied this bump to `important-service` first ([#18](https://github.com/giantswarm/important-service/pull/18)) and `ci/circleci: push-to-catalog` went from **failing to passing**. This is the same change.

## Why 9.6.0 and not v10.0.0

v10.0.0 is a day old with no production usage in the org. 9.6.0 is what `coredns-app`, `external-dns-app` and `kyverno-policies-dx` run today with passing catalog pushes.

Both are compatible — I checked every job and parameter used across all 7 affected repos against both refs and nothing is missing. v10's only change deprecates `override_chart_version`, which none of these configs pass, so Renovate's eventual v10 bump should be uneventful.

## Compatibility

Every orb job used across these repos — `go-build`, `go-test`, `integration-test`, `push-to-app-catalog`, `push-to-registries`, `run-tests-with-ats` — exists at 9.6.0, and every parameter passed is present.

Two removals in 9.0.0 worth naming, neither of which bites: the `architect`-executor path in `push-to-app-catalog` is gone (these configs pass `app-build-suite`, the surviving path and now the only enum value), and `multiarch` / `os` / singular `architecture` are gone from `go-build`/`push-to-registries` (none of these configs set them).

## Heads-up on what this reveals

Unblocking the chart push lets downstream jobs run for the first time in months, which can surface unrelated rot. On `important-service`, `run-tests-with-ats` then failed because the chart pins `gsoci.azurecr.io/giantswarm/helloworld:0.5.0-2926c5bb67b99209ca7f94bfc65b32ad5f2d461e`, which now 404s (clean tags like `0.5.0` still exist) — a separate, pre-existing issue, not caused by this bump.

One of 7 repositories with this same failure, all still on orb 6.x.
