### PR TITLE
fix: bump appcatalog to v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
+
+### Fixed
+
+- Bump `appcatalog` to v1.0.2, fixing `basic-integration-test`. `integration/setup/setup.go` calls
+  `appcatalog.GetLatestChart(..., env.CircleSHA())`, and appcatalog matched the index entry with
+  `strings.HasSuffix(entry.Version, appVersion)`. That worked while architect published charts as
+  `<version>-<full 40 character SHA>`, but since the architect orb bump to 9.x the published format is
+  the gitsemver development version, e.g. `4.2.1-dev.<branch>.2026-08-19.13-58-39.ha781825`, whose
+  trailing SHA is abbreviated to seven characters. A full SHA can never match that by suffix, so the
+  lookup failed with `no app ... in index.yaml with given appVersion` even though the chart was
+  published correctly. appcatalog v1.0.2 accepts both formats.
+
 ## [4.2.0] - 2025-11-26
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/appcatalog v1.0.1
+	github.com/giantswarm/appcatalog v1.0.2
 	github.com/giantswarm/backoff v1.0.1
 	github.com/giantswarm/exporterkit v1.3.0
 	github.com/giantswarm/helmclient/v4 v4.12.9

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/getsentry/sentry-go v0.31.1 h1:ELVc0h7gwyhnXHDouXkhqTFSO5oslsRDk0++ey
 github.com/getsentry/sentry-go v0.31.1/go.mod h1:CYNcMMz73YigoHljQRG+qPF+eMq8gG72XcGN/p71BAY=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/appcatalog v1.0.1 h1:hUBN5CTGbfMYiO28XihSf7kUnnPguTLOBr9BAtqfKK4=
-github.com/giantswarm/appcatalog v1.0.1/go.mod h1:mL+OaULPRgdnf91Vws1pmyvqVxx16t89s4kDF/O/ps0=
+github.com/giantswarm/appcatalog v1.0.2 h1:1k2iiQ60atiIP1TzKMpCxyK9mTMcX3Dk16NoenDK/VA=
+github.com/giantswarm/appcatalog v1.0.2/go.mod h1:22bcRghWPjOuZ60KY46DoOI85YinTEaCQROJVF1C+iQ=
 github.com/giantswarm/backoff v1.0.1 h1:paqQhjUsibkf+wWFCHsk7VXAkcM1L3ssAe7V7i8twpM=
 github.com/giantswarm/backoff v1.0.1/go.mod h1:RGj8b06J3irMNFRoSiMnngS50K+QbpSvu77sW03bxqQ=
 github.com/giantswarm/exporterkit v1.3.0 h1:AVIJD5R277/m8eDl4agxLXg35KvW2jJWb1W6+jKNAUg=


### PR DESCRIPTION
### Why

`ci/circleci: basic-integration-test` has failed since the architect orb bump to 9.x.

`integration/setup/setup.go` resolves the chart under test with:

```go
appcatalog.GetLatestChart(ctx, key.DefaultTestCatalogStorageURL(), project.Name(), env.CircleSHA())
```

`appcatalog` selected the index entry with `strings.HasSuffix(entry.Version, appVersion)`. That matched
while architect published charts as `<version>-<full 40 character SHA>`. Orb 9.x publishes the gitsemver
development version instead, whose trailing SHA is abbreviated to **seven** characters — so a full SHA
can never match by suffix, and the lookup fails with `no app ... in index.yaml with given appVersion`
even though the chart was published correctly.

[appcatalog#303](https://github.com/giantswarm/appcatalog/pull/303), released as **v1.0.2**, accepts
both formats.

### What changed

`go get github.com/giantswarm/appcatalog@v1.0.2` plus `go mod tidy` — only `go.mod` and `go.sum`
change. `go build ./...` passes.

### Note

The same one-line bump is going to `app-operator` and `apptest`, which hit this the same way. This is
what Renovate would raise on its own; opening it directly so the integration tests stop being red in
the meantime.